### PR TITLE
Build GitHub Pages homepage and detailed docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 dumb.rdb
+.superpowers/
+.worktrees/
+.bundle/
+_site/
+vendor/bundle/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Build Your Own Redis in Rust
 
+Project site: [https://fangpin.github.io/redis-rs/](https://fangpin.github.io/redis-rs/)
+Docs overview: [https://fangpin.github.io/redis-rs/docs/overview/](https://fangpin.github.io/redis-rs/docs/overview/)
+
 This project is to build a toy Redis-Server clone that's capable of parsing Redis protocol and handling basic Redis commands, parsing and initializing Redis from RDB file,
 supporting leader-follower replication, redis streams (queue), redis batch commands in transaction.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,5 +1,8 @@
 # 使用 Rust 构建你自己的 Redis
 
+项目主页: [https://fangpin.github.io/redis-rs/](https://fangpin.github.io/redis-rs/)
+文档总览: [https://fangpin.github.io/redis-rs/zh/docs/overview/](https://fangpin.github.io/redis-rs/zh/docs/overview/)
+
 该项目旨在构建一个玩具 Redis-Server，它能够解析 Redis 协议并处理基本的 Redis 命令; 将 Redis 持久化化到 RDB 文件中；从 RDB 文件解析和初始化 Redis，
 支持主从复制、Redis 流。
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,15 @@
 title: 从 0 到 1 由 Rust 构建 Redis
 description: 从 0 到 1 由 Rust 构建 Redis
 theme: just-the-docs
+color_scheme: redis-rs
 
-url: https://fangpin.github.io/redis-rs
+url: https://fangpin.github.io
 
 aux_links:
-  GitHub: https://fangpin.github.io/redis-rs
+  GitHub: https://github.com/fangpin/redis-rs
+
+exclude:
+  - docs/superpowers/
 
 # logo: "/assets/images/just-the-docs.png"
 

--- a/_sass/color_schemes/redis-rs.scss
+++ b/_sass/color_schemes/redis-rs.scss
@@ -1,0 +1,23 @@
+$color-scheme: dark;
+
+$body-background-color: #07111f;
+$body-heading-color: #ecf7ff;
+$body-text-color: rgba(#ecf7ff, 0.82);
+$link-color: #79f0ff;
+$nav-child-link-color: rgba(#ecf7ff, 0.68);
+$sidebar-color: #081524;
+$base-button-color: #0d2033;
+$btn-primary-color: #79f0ff;
+$code-background-color: #0b1829;
+$code-linenumber-color: #9ecfe4;
+$feedback-color: #10263b;
+$table-background-color: #0a1626;
+$search-background-color: #081524;
+$search-result-preview-color: rgba(#ecf7ff, 0.62);
+$border-color: rgba(#79f0ff, 0.22);
+
+$redis-panel-background: rgba(#081524, 0.88);
+$redis-panel-background-strong: rgba(#0a1626, 0.94);
+$redis-accent-strong: #9dffb8;
+
+@import "./vendor/OneDarkJekyll/syntax";

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,174 @@
+body {
+  background:
+    radial-gradient(circle at top left, rgba($link-color, 0.18), transparent 28%),
+    radial-gradient(circle at 85% 10%, rgba($redis-accent-strong, 0.12), transparent 18%),
+    linear-gradient(180deg, #050b14, #091426 45%, $body-background-color 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba($link-color, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba($link-color, 0.05) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(180deg, rgba(#fff, 0.45), transparent 82%);
+}
+
+.side-bar {
+  background: $redis-panel-background;
+  backdrop-filter: blur(18px);
+
+  @include mq(md) {
+    box-shadow: 18px 0 48px rgba(0, 0, 0, 0.26);
+  }
+}
+
+.site-header,
+.main-header {
+  backdrop-filter: blur(18px);
+}
+
+.site-header {
+  background: rgba($body-background-color, 0.82);
+}
+
+.side-bar + .main .main-header {
+  background: $redis-panel-background-strong;
+}
+
+.search-input-wrap,
+.search-results,
+.table-wrapper,
+.main-content blockquote,
+pre.highlight,
+.highlight pre {
+  border: 1px solid $border-color;
+  background: $redis-panel-background-strong;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+}
+
+.search-input-wrap {
+  border-radius: 12px;
+
+  @include mq(md) {
+    border-radius: 0;
+    border-left: 1px solid $border-color;
+  }
+}
+
+.search-input,
+.search-results,
+.search-result,
+.search-result-previews {
+  background-color: transparent;
+}
+
+.search-input {
+  color: $body-text-color;
+
+  &::placeholder {
+    color: rgba($body-text-color, 0.6);
+  }
+}
+
+.search-label .search-icon {
+  color: rgba($body-text-color, 0.62);
+}
+
+.search-result:hover,
+.search-result.active {
+  background-color: rgba($link-color, 0.12);
+}
+
+.site-title,
+.nav-list .nav-list-item .nav-list-link,
+.nav-list .nav-list-item .nav-list-expander,
+.aux-nav .site-button {
+  color: $body-heading-color;
+}
+
+.nav-list .nav-list-item .nav-list-link {
+  color: rgba($body-heading-color, 0.74);
+  transition: background 180ms ease, color 180ms ease;
+}
+
+.nav-list .nav-list-item .nav-list-link:hover,
+.nav-list .nav-list-item .nav-list-link.active,
+.site-title:hover,
+.site-button:hover {
+  background-image: linear-gradient(
+    -90deg,
+    rgba($link-color, 0.16) 0%,
+    rgba($link-color, 0.08) 80%,
+    rgba($link-color, 0) 100%
+  );
+}
+
+.nav-list .nav-list-item > .nav-list .nav-list-item .nav-list-link,
+.nav-list .nav-list-item > .nav-list .nav-list-item .nav-list-expander {
+  color: $nav-child-link-color;
+}
+
+.site-button {
+  color: $link-color;
+}
+
+.main-content {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: $body-heading-color;
+  }
+
+  h2,
+  h3 {
+    padding-top: 0.9rem;
+    border-top: 1px solid rgba($border-color, 0.65);
+  }
+
+  a:not([class]) {
+    text-decoration-color: rgba($link-color, 0.45);
+  }
+
+  code {
+    color: $redis-accent-strong;
+  }
+
+  ul > li::before,
+  ol > li::before {
+    color: rgba($link-color, 0.75);
+  }
+
+  blockquote {
+    padding: 1rem 1.25rem;
+    border-left-color: rgba($link-color, 0.7);
+    border-radius: 0 12px 12px 0;
+  }
+}
+
+thead th {
+  background: rgba($link-color, 0.08);
+}
+
+tbody tr:nth-child(2n) td {
+  background: rgba($white, 0.02);
+}
+
+th,
+td {
+  border-color: rgba($border-color, 0.9);
+}
+
+hr {
+  background-color: $border-color;
+}
+
+.site-footer {
+  color: rgba($body-text-color, 0.65);
+}

--- a/_sass/custom/setup.scss
+++ b/_sass/custom/setup.scss
@@ -1,0 +1,3 @@
+$redis-panel-background: rgba(#081524, 0.88) !default;
+$redis-panel-background-strong: rgba(#0a1626, 0.94) !default;
+$redis-accent-strong: #9dffb8 !default;

--- a/assets/css/homepage.css
+++ b/assets/css/homepage.css
@@ -1,0 +1,543 @@
+:root {
+  color-scheme: dark;
+  --bg: #07111f;
+  --bg-elevated: rgba(11, 24, 41, 0.8);
+  --bg-panel: rgba(10, 20, 34, 0.92);
+  --line: rgba(122, 238, 255, 0.18);
+  --line-strong: rgba(122, 238, 255, 0.38);
+  --text: #ecf7ff;
+  --text-dim: rgba(236, 247, 255, 0.72);
+  --accent: #79f0ff;
+  --accent-strong: #9dffb8;
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  --content-width: 1180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at top left, rgba(121, 240, 255, 0.18), transparent 28%),
+    radial-gradient(circle at 85% 10%, rgba(157, 255, 184, 0.12), transparent 18%),
+    linear-gradient(180deg, #050b14, #091426 45%, #07111f 100%);
+  color: var(--text);
+  font-family: "Manrope", system-ui, sans-serif;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(121, 240, 255, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(121, 240, 255, 0.05) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(180deg, rgba(255, 255, 255, 0.45), transparent 82%);
+}
+
+.page-shell {
+  width: min(calc(100% - 32px), var(--content-width));
+  margin: 0 auto;
+  padding: 24px 0 56px;
+}
+
+.topbar,
+.hero-content,
+.section,
+.footer-cta {
+  backdrop-filter: blur(18px);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(6, 14, 25, 0.7);
+}
+
+.brand,
+.text-link,
+.button,
+.inline-link {
+  text-decoration: none;
+}
+
+.brand {
+  color: var(--text);
+  font-family: "Chakra Petch", sans-serif;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.text-link {
+  color: var(--text-dim);
+  font-size: 0.95rem;
+}
+
+.language-toggle {
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.lang-btn {
+  border: 0;
+  min-width: 60px;
+  padding: 9px 14px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  cursor: pointer;
+}
+
+.lang-btn.is-active {
+  background: linear-gradient(135deg, rgba(121, 240, 255, 0.22), rgba(157, 255, 184, 0.18));
+  color: var(--text);
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 28px;
+  margin-top: 20px;
+  padding: 36px;
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background:
+    linear-gradient(145deg, rgba(8, 21, 36, 0.96), rgba(8, 17, 31, 0.86)),
+    radial-gradient(circle at top right, rgba(121, 240, 255, 0.12), transparent 26%);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.docs-entry-section {
+  margin-top: 20px;
+  padding: 24px 26px;
+  border: 1px solid var(--line-strong);
+  border-radius: 24px;
+  background:
+    linear-gradient(145deg, rgba(8, 20, 34, 0.94), rgba(8, 16, 29, 0.84)),
+    radial-gradient(circle at right center, rgba(121, 240, 255, 0.12), transparent 28%);
+  box-shadow: var(--shadow);
+}
+
+.docs-entry-header,
+.docs-link-grid {
+  display: grid;
+}
+
+.docs-entry-header {
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.docs-entry-header h2 {
+  max-width: 18ch;
+  font-family: "Chakra Petch", sans-serif;
+  font-size: clamp(1.6rem, 2.6vw, 2.5rem);
+  line-height: 1.02;
+}
+
+.docs-entry-button {
+  min-width: 180px;
+}
+
+.docs-link-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.docs-link-card {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+  text-decoration: none;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.docs-link-card:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+  background: rgba(121, 240, 255, 0.06);
+}
+
+.docs-link-kicker {
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-link-card strong {
+  color: var(--text);
+  font-size: 1.02rem;
+}
+
+.docs-link-copy {
+  color: var(--text-dim);
+  line-height: 1.6;
+  font-size: 0.92rem;
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.card-kicker,
+.command-label,
+.node-file,
+.metric-label {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin: 0 0 16px;
+  color: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  max-width: 10ch;
+  font-family: "Chakra Petch", sans-serif;
+  font-size: clamp(3rem, 7vw, 5.8rem);
+  line-height: 0.95;
+}
+
+.hero-description {
+  margin-top: 18px;
+  max-width: 58ch;
+  color: var(--text-dim);
+  font-size: 1.04rem;
+  line-height: 1.75;
+}
+
+.hero-actions,
+.footer-actions {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.hero-actions {
+  margin-top: 28px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 18px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.button:hover,
+.lang-btn:hover,
+.text-link:hover {
+  transform: translateY(-1px);
+}
+
+.button-primary {
+  background: linear-gradient(135deg, rgba(121, 240, 255, 0.2), rgba(157, 255, 184, 0.22));
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.button-secondary {
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text);
+  border-color: var(--line);
+}
+
+.panel-surface {
+  width: 100%;
+  min-height: 100%;
+  padding: 22px;
+  border: 1px solid rgba(121, 240, 255, 0.18);
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, rgba(8, 18, 30, 0.94), rgba(12, 29, 46, 0.88)),
+    radial-gradient(circle at top left, rgba(121, 240, 255, 0.08), transparent 30%);
+}
+
+.panel-header,
+.panel-grid,
+.capability-grid,
+.command-deck,
+.architecture-strip {
+  display: grid;
+}
+
+.panel-header {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  color: var(--text-dim);
+  font-size: 0.78rem;
+}
+
+.panel-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.metric,
+.capability-card,
+.command-card,
+.architecture-node,
+.footer-cta {
+  border: 1px solid var(--line);
+  background: var(--bg-elevated);
+}
+
+.metric {
+  padding: 14px;
+  border-radius: 16px;
+}
+
+.metric strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.35rem;
+}
+
+.signal-code {
+  margin-top: 18px;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(4, 10, 18, 0.92);
+  color: #b8ffe0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.88rem;
+  line-height: 1.7;
+  overflow: auto;
+}
+
+.section,
+.footer-cta {
+  margin-top: 24px;
+  padding: 28px;
+  border-radius: 26px;
+  background: rgba(6, 15, 27, 0.72);
+}
+
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.section-heading h2,
+.footer-cta h2 {
+  max-width: 22ch;
+  font-family: "Chakra Petch", sans-serif;
+  font-size: clamp(1.8rem, 3vw, 2.9rem);
+  line-height: 1.02;
+}
+
+.capability-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.capability-card,
+.architecture-node {
+  padding: 20px;
+  border-radius: 18px;
+}
+
+.card-kicker,
+.command-label,
+.node-file,
+.metric-label {
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.capability-card h3,
+.architecture-node h3 {
+  margin-top: 14px;
+  font-size: 1.18rem;
+}
+
+.capability-card p,
+.architecture-node p {
+  margin-top: 10px;
+  color: var(--text-dim);
+  line-height: 1.65;
+}
+
+.chip {
+  display: inline-flex;
+  margin-top: 14px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: rgba(121, 240, 255, 0.08);
+  color: var(--text);
+  font-size: 0.82rem;
+}
+
+.inline-link {
+  display: inline-flex;
+  margin-top: 14px;
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.command-deck {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.command-card {
+  padding: 18px;
+  border-radius: 18px;
+}
+
+.command-card-wide {
+  grid-column: 1 / -1;
+}
+
+.command-card pre,
+.command-card code {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.command-card pre {
+  overflow: auto;
+  margin-top: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(3, 9, 18, 0.94);
+  color: #d8fff0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  line-height: 1.7;
+}
+
+.architecture-strip {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.footer-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+@media (max-width: 1080px) {
+  .hero-content,
+  .docs-link-grid,
+  .capability-grid,
+  .architecture-strip {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .page-shell {
+    width: min(calc(100% - 20px), var(--content-width));
+    padding-top: 12px;
+  }
+
+  .topbar,
+  .hero-content,
+  .docs-entry-section,
+  .section,
+  .footer-cta {
+    padding: 20px;
+  }
+
+  .hero-content,
+  .docs-entry-header,
+  .capability-grid,
+  .docs-link-grid,
+  .command-deck,
+  .architecture-strip,
+  .footer-cta {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-cta {
+    display: grid;
+  }
+}
+
+@media (max-width: 560px) {
+  h1 {
+    max-width: none;
+    font-size: clamp(2.4rem, 15vw, 3.5rem);
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .topbar-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero-actions,
+  .footer-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -1,0 +1,343 @@
+const translations = {
+  en: {
+    meta: {
+      title: "redis-rs | Build Your Own Redis in Rust",
+      description:
+        "A Redis clone in Rust with RESP parsing, RDB loading, replication, streams, and transactions.",
+      languageSwitcher: "Language switcher",
+    },
+    nav: {
+      overview: "Detailed Docs",
+      overviewHref: "/redis-rs/docs/overview/",
+      github: "GitHub",
+    },
+    hero: {
+      eyebrow: "Protocol. Persistence. Replication.",
+      title: "Build Your Own Redis in Rust",
+      description:
+        "A toy Redis server in Rust that parses RESP, restores from RDB, replicates leader-follower state, supports streams, and queues transactional commands.",
+      primaryCta: "View on GitHub",
+      secondaryCta: "Quick Start",
+      docsCta: "Detailed Docs",
+      docsHref: "/redis-rs/docs/overview/",
+    },
+    docsEntry: {
+      eyebrow: "Implementation docs",
+      title: "Go straight to the detailed implementation docs",
+      primaryCta: "Docs overview",
+      primaryHref: "/redis-rs/docs/overview/",
+      runtime: {
+        kicker: "Runtime",
+        title: "Server runtime",
+        body: "Process entry, configuration, listener lifecycle, and shared server state.",
+        href: "/redis-rs/docs/server-runtime/",
+      },
+      protocol: {
+        kicker: "Protocol",
+        title: "RESP and storage",
+        body: "Wire format, parser, string storage, expiry, and stream containers.",
+        href: "/redis-rs/docs/resp-protocol/",
+      },
+      replication: {
+        kicker: "Sync",
+        title: "RDB and replication",
+        body: "Snapshot parsing, handshake flow, full sync, and replica fan-out.",
+        href: "/redis-rs/docs/replication-flow/",
+      },
+      commands: {
+        kicker: "Behavior",
+        title: "Commands and transactions",
+        body: "Dispatch, stream semantics, transaction replay, and the full chapter map.",
+        href: "/redis-rs/docs/command-execution/",
+      },
+    },
+    metrics: {
+      protocol: "Protocol",
+      persistence: "Persistence",
+      replication: "Replication",
+      streams: "Queues",
+    },
+    capabilities: {
+      eyebrow: "Core capabilities",
+      title: "Built around real Redis subsystems",
+      protocol: {
+        title: "Protocol",
+        body: "Parses Redis protocol messages and routes commands through the server runtime.",
+      },
+      persistence: {
+        title: "Persistence",
+        body: "Loads database state from RDB files and restores key metadata.",
+      },
+      replication: {
+        title: "Replication",
+        body: "Bootstraps replica handshake, full sync, and replicated write flow.",
+      },
+      streams: {
+        title: "Streams and transactions",
+        body: "Supports stream operations and queued transactional execution patterns.",
+      },
+    },
+    quickstart: {
+      eyebrow: "Run it",
+      title: "Start fast, then probe with redis-cli",
+      masterLabel: "Master",
+      replicaLabel: "Replica",
+      probeLabel: "Probe",
+    },
+    architecture: {
+      eyebrow: "Implementation map",
+      title: "How the runtime is assembled",
+      protocol: {
+        title: "Protocol ingestion",
+        body: "RESP parsing and request framing for incoming client and replication traffic.",
+      },
+      command: {
+        title: "Command routing",
+        body: "Connection handling, command dispatch, and transaction orchestration.",
+      },
+      storage: {
+        title: "State and restore",
+        body: "In-memory storage backed by RDB parsing and initial database hydration.",
+      },
+      replication: {
+        title: "Replication flow",
+        body: "Replica-side handshake, sync start, and downstream command consumption.",
+      },
+    },
+    docs: {
+      eyebrow: "Implementation docs",
+      title: "Follow the code by subsystem",
+      openChapter: "Open chapter",
+      openOverview: "Open overview",
+      runtime: {
+        title: "Server runtime",
+        body: "Process entry, configuration, listener lifecycle, and shared server state.",
+        href: "/redis-rs/docs/server-runtime/",
+      },
+      persistence: {
+        title: "RESP and storage",
+        body: "RESP parsing and encoding, string storage, expiry model, and stream containers.",
+        href: "/redis-rs/docs/resp-protocol/",
+      },
+      commands: {
+        title: "Persistence and replication",
+        body: "RDB parser internals, handshake flow, full sync, and replica fan-out.",
+        href: "/redis-rs/docs/replication-flow/",
+      },
+      overview: {
+        title: "Command surface",
+        body: "Command dispatch, stream semantics, transaction replay, and the full chapter map.",
+        href: "/redis-rs/docs/overview/",
+      },
+    },
+    footer: {
+      eyebrow: "Source and docs",
+      title: "Inspect the code, then dive deeper",
+      github: "Open GitHub Repository",
+      readmeEn: "Read README",
+      readmeZh: "Read Chinese README",
+    },
+  },
+  zh: {
+    meta: {
+      title: "redis-rs | 用 Rust 构建自己的 Redis",
+      description:
+        "一个用 Rust 编写的 toy Redis server，支持 RESP 解析、RDB 恢复、主从复制、Stream，以及事务命令排队执行。",
+      languageSwitcher: "语言切换",
+    },
+    nav: {
+      overview: "详细文档",
+      overviewHref: "/redis-rs/zh/docs/overview/",
+      github: "GitHub",
+    },
+    hero: {
+      eyebrow: "协议。持久化。复制。",
+      title: "用 Rust 构建自己的 Redis",
+      description:
+        "一个用 Rust 编写的 toy Redis server，支持 RESP 解析、RDB 恢复、主从复制、Stream，以及事务命令排队执行。",
+      primaryCta: "查看 GitHub 仓库",
+      secondaryCta: "快速开始",
+      docsCta: "详细文档",
+      docsHref: "/redis-rs/zh/docs/overview/",
+    },
+    docsEntry: {
+      eyebrow: "实现文档",
+      title: "直接进入详细实现文档",
+      primaryCta: "文档总览",
+      primaryHref: "/redis-rs/zh/docs/overview/",
+      runtime: {
+        kicker: "运行时",
+        title: "运行时与服务端",
+        body: "进程入口、配置模型、监听生命周期，以及共享服务端状态。",
+        href: "/redis-rs/zh/docs/server-runtime/",
+      },
+      protocol: {
+        kicker: "协议层",
+        title: "RESP 与存储",
+        body: "线协议解析与编码、字符串存储、过期模型，以及 stream 容器结构。",
+        href: "/redis-rs/zh/docs/resp-protocol/",
+      },
+      replication: {
+        kicker: "同步链路",
+        title: "RDB 与复制",
+        body: "快照解析、握手流程、全量同步，以及 replica fan-out。",
+        href: "/redis-rs/zh/docs/replication-flow/",
+      },
+      commands: {
+        kicker: "行为层",
+        title: "命令与事务",
+        body: "命令分发、stream 语义、事务重放，以及完整章节地图。",
+        href: "/redis-rs/zh/docs/command-execution/",
+      },
+    },
+    metrics: {
+      protocol: "协议",
+      persistence: "持久化",
+      replication: "复制",
+      streams: "队列",
+    },
+    capabilities: {
+      eyebrow: "核心能力",
+      title: "围绕真实 Redis 子系统构建",
+      protocol: {
+        title: "协议处理",
+        body: "解析 Redis 协议消息，并把命令路由到服务端运行时。",
+      },
+      persistence: {
+        title: "持久化",
+        body: "从 RDB 文件加载数据库状态，并恢复键的元数据。",
+      },
+      replication: {
+        title: "主从复制",
+        body: "完成 replica 握手、全量同步和写命令复制流程。",
+      },
+      streams: {
+        title: "流与事务",
+        body: "支持 Stream 相关操作，以及事务命令排队和执行模式。",
+      },
+    },
+    quickstart: {
+      eyebrow: "开始运行",
+      title: "先跑起来，再用 redis-cli 探测",
+      masterLabel: "主节点",
+      replicaLabel: "从节点",
+      probeLabel: "探测命令",
+    },
+    architecture: {
+      eyebrow: "实现映射",
+      title: "运行时如何拼装起来",
+      protocol: {
+        title: "协议入口",
+        body: "负责 RESP 解析，以及客户端与复制流量的请求分帧。",
+      },
+      command: {
+        title: "命令路由",
+        body: "负责连接处理、命令分发，以及事务编排。",
+      },
+      storage: {
+        title: "状态与恢复",
+        body: "以内存存储为核心，并由 RDB 解析完成初始数据装载。",
+      },
+      replication: {
+        title: "复制链路",
+        body: "负责 replica 侧握手、同步启动和下游命令消费。",
+      },
+    },
+    docs: {
+      eyebrow: "实现文档",
+      title: "按子系统阅读代码",
+      openChapter: "打开章节",
+      openOverview: "打开总览",
+      runtime: {
+        title: "运行时与服务端",
+        body: "进程入口、配置模型、监听生命周期，以及共享服务端状态。",
+        href: "/redis-rs/zh/docs/server-runtime/",
+      },
+      persistence: {
+        title: "RESP 与存储",
+        body: "RESP 解析与编码、字符串存储、过期模型，以及 stream 容器结构。",
+        href: "/redis-rs/zh/docs/resp-protocol/",
+      },
+      commands: {
+        title: "持久化与复制",
+        body: "RDB 解析器内部、握手流程、全量同步，以及 replica fan-out。",
+        href: "/redis-rs/zh/docs/replication-flow/",
+      },
+      overview: {
+        title: "命令执行面",
+        body: "命令分发、Stream 语义、事务重放，以及完整章节地图。",
+        href: "/redis-rs/zh/docs/overview/",
+      },
+    },
+    footer: {
+      eyebrow: "源码与文档",
+      title: "先看代码，再继续深入",
+      github: "打开 GitHub 仓库",
+      readmeEn: "查看英文 README",
+      readmeZh: "查看中文 README",
+    },
+  },
+};
+
+const LANG_STORAGE_KEY = "redis-rs-homepage-language";
+
+function getValue(source, path) {
+  return path.split(".").reduce((acc, key) => acc && acc[key], source);
+}
+
+function applyLanguage(lang) {
+  const dictionary = translations[lang] || translations.en;
+  document.documentElement.lang = lang === "zh" ? "zh-CN" : "en";
+  document.title = dictionary.meta.title;
+
+  document.querySelectorAll("[data-i18n]").forEach((node) => {
+    const value = getValue(dictionary, node.dataset.i18n);
+    if (typeof value === "string") {
+      node.textContent = value;
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-content]").forEach((node) => {
+    const value = getValue(dictionary, node.dataset.i18nContent);
+    if (typeof value === "string") {
+      node.setAttribute("content", value);
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-aria-label]").forEach((node) => {
+    const value = getValue(dictionary, node.dataset.i18nAriaLabel);
+    if (typeof value === "string") {
+      node.setAttribute("aria-label", value);
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-href]").forEach((node) => {
+    const value = getValue(dictionary, node.dataset.i18nHref);
+    if (typeof value === "string") {
+      node.setAttribute("href", value);
+    }
+  });
+
+  document.querySelectorAll(".lang-btn").forEach((button) => {
+    const active = button.dataset.lang === lang;
+    button.classList.toggle("is-active", active);
+    button.setAttribute("aria-pressed", String(active));
+  });
+
+  window.localStorage.setItem(LANG_STORAGE_KEY, lang);
+}
+
+function preferredLanguage() {
+  const saved = window.localStorage.getItem(LANG_STORAGE_KEY);
+  return saved === "zh" ? "zh" : "en";
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  applyLanguage(preferredLanguage());
+
+  document.querySelectorAll(".lang-btn").forEach((button) => {
+    button.addEventListener("click", () => {
+      applyLanguage(button.dataset.lang === "zh" ? "zh" : "en");
+    });
+  });
+});

--- a/docs/command-execution.md
+++ b/docs/command-execution.md
@@ -1,0 +1,138 @@
+---
+title: Command Execution
+layout: default
+nav_order: 8
+permalink: /docs/command-execution/
+---
+
+# Command Execution
+
+This chapter focuses on how parsed protocol values become typed commands and how those commands dispatch into concrete behaviors.
+
+## File boundaries
+
+- `src/cmd.rs`
+- `src/server.rs`
+- `src/protocol.rs`
+
+## Why `cmd.rs` is the center of behavior
+
+`src/cmd.rs` is the largest behavior module in the repo. It is where:
+
+- protocol arrays become command enums
+- command handlers are dispatched
+- write commands intersect with replication
+- streams and transactions attach themselves to the normal command path
+
+If `server.rs` is the runtime shell, `cmd.rs` is the semantic heart of the server.
+
+## Command enum
+
+`Cmd` is a typed summary of the supported command surface.
+
+It currently includes:
+
+- string commands such as `GET`, `SET`, `DEL`, `INCR`
+- inspection commands such as `CONFIG GET`, `INFO`, `TYPE`
+- replication commands such as `REPLCONF`, `PSYNC`
+- stream commands such as `XADD`, `XRANGE`, `XREAD`
+- transaction commands such as `MULTI`, `EXEC`, `DISCARD`
+
+Unknown inputs fall into `Unknow`.
+
+## Parsing path
+
+`Cmd::from(...)` starts from a parsed `Protocol` and expects the top-level shape to be an array.
+
+The control flow is:
+
+1. call `Protocol::from(...)`
+2. ensure the top-level value is `Protocol::Array`
+3. decode each child into a flat token vector
+4. match on the first token
+5. validate argument count and shape for each supported command
+6. return `(Cmd, Protocol)`
+
+Returning the original `Protocol` together with the typed command is important because replication later needs the exact command payload again.
+
+## Dispatch path
+
+`Cmd::run(...)` is the central dispatcher.
+
+Its inputs are:
+
+- `&mut Server`
+- original `Protocol`
+- `is_rep_con`
+- `queued_cmd`
+
+Its output is always `Result<Protocol, DBError>`.
+
+The dispatch table sends each command to a focused helper such as:
+
+- `get_cmd(...)`
+- `set_cmd(...)`
+- `keys_cmd(...)`
+- `info_cmd(...)`
+- `xadd_cmd(...)`
+- `exec_cmd(...)`
+
+That keeps parsing, orchestration, and individual command semantics separate.
+
+## Shared write helper
+
+Several write commands end in `resp_and_replicate(...)`.
+
+That helper decides:
+
+- what local response should be returned
+- whether the command should be forwarded to registered replicas
+- whether a slave should reject the write
+
+This is a useful design choice because replication rules are not duplicated across every write handler.
+
+## Introspection commands
+
+`config_get_cmd(...)` and `info_cmd(...)` expose parts of the runtime configuration and replication state.
+
+These commands do not touch storage directly. They serialize fields from `server.option` into `Protocol` values.
+
+That gives the repo a lightweight self-description surface without adding separate metadata layers.
+
+## Keys and type inspection
+
+`keys_cmd(...)` simply returns the current keys from string storage.
+
+`type_cmd(...)` checks both containers:
+
+1. string storage
+2. stream map
+
+and returns `string`, `stream`, or `none`.
+
+That small helper is one of the places where the repo's split between normal storage and streams becomes visible to clients.
+
+## Incr path
+
+`incr_cmd(...)` reads the current string value, defaults missing keys to `1`, parses the value as `u64`, increments it, then stores the result back as a string.
+
+If parsing fails, it returns an explicit Redis-style error message.
+
+This is a compact example of how command helpers sit above the string-only storage model rather than replacing it.
+
+## Offset accounting
+
+After a successful command, `Cmd::run(...)` increments `server.offset` by the encoded length of the original protocol payload.
+
+That means offset accounting is attached to command completion, not socket read position.
+
+It is a crude model, but it is consistent across the command layer.
+
+## Current implementation limits
+
+- command parsing assumes fully decoded arrays
+- unsupported shapes error out early
+- many handlers still unwrap or assume well-formed values
+- unknown commands collapse into one generic branch
+
+Even with those limits, `cmd.rs` does a good job showing the command-oriented structure of a Redis-like server.

--- a/docs/commands-streams-and-transactions.md
+++ b/docs/commands-streams-and-transactions.md
@@ -1,0 +1,141 @@
+---
+title: Commands, Streams, and Transactions
+layout: default
+nav_exclude: true
+permalink: /docs/commands-streams-and-transactions/
+---
+
+# Commands, Streams, and Transactions
+
+This chapter covers command decoding, the command execution surface, and the parts of the runtime that go beyond basic key-value storage.
+
+## File boundaries
+
+- `src/cmd.rs`
+- `src/storage.rs`
+- `src/server.rs`
+
+## Command decoding
+
+`Cmd::from(...)` converts a parsed RESP array into a typed command enum.
+
+The command surface currently includes:
+
+- `PING`
+- `ECHO`
+- `GET`
+- `SET`
+- `SET PX`
+- `SET EX`
+- `DEL`
+- `KEYS *`
+- `CONFIG GET`
+- `INFO`
+- `TYPE`
+- `INCR`
+- `REPLCONF`
+- `PSYNC`
+- `XADD`
+- `XRANGE`
+- `XREAD`
+- `MULTI`
+- `EXEC`
+- `DISCARD`
+
+This enum is the main command boundary for the whole server.
+
+## Execution path
+
+`Cmd::run(...)` is the dispatch hub. It receives:
+
+- the mutable `Server`
+- the original `Protocol`
+- a flag telling whether the connection is a replication connection
+- the current queued transaction state
+
+The function routes each command into a smaller helper such as:
+
+- `get_cmd(...)`
+- `set_cmd(...)`
+- `xadd_cmd(...)`
+- `xread_cmd(...)`
+- `exec_cmd(...)`
+
+That keeps parsing and execution separate: `Cmd::from(...)` answers "what command is this?" while `run(...)` answers "what should it do?"
+
+## Basic storage commands
+
+For string keys, `cmd.rs` ultimately delegates to `Storage`:
+
+- `GET` calls into `storage.get(...)`
+- `SET` and timed `SET` paths call `set(...)` or `setx(...)`
+- `DEL` removes keys
+- `INCR` builds on the stored string representation and updates the same key
+
+The key-value layer is intentionally string-based, which keeps both RDB loading and RESP round-tripping simple.
+
+## Stream model
+
+`Server` stores streams separately from ordinary keys:
+
+```text
+HashMap<String, BTreeMap<String, Vec<(String, String)>>>
+```
+
+Conceptually:
+
+- top-level key -> stream name
+- inner `BTreeMap` -> ordered stream entry ids
+- entry payload -> field/value pairs
+
+This design makes ordered range reads straightforward because `BTreeMap` preserves key ordering.
+
+## Stream commands
+
+The stream surface in `cmd.rs` includes:
+
+- `XADD`
+- `XRANGE`
+- `XREAD`
+
+Important responsibilities handled in the command layer:
+
+- validating stream IDs
+- generating IDs for `*`
+- reading by range
+- reading from one or many streams
+- optional blocking behavior for `XREAD`
+
+Blocking reads coordinate through `server.stream_reader_blocker`, which gives the implementation a simple wake-up path when new entries arrive.
+
+## Transactions
+
+The transaction implementation is centered on `queued_cmd: Option<Vec<(Cmd, Protocol)>>`.
+
+Behavior:
+
+- `MULTI` creates an empty queue
+- ordinary commands after `MULTI` are appended and return `QUEUED`
+- `EXEC` replays the queued commands in order
+- `DISCARD` clears the queue
+
+This is a compact design because it reuses:
+
+- the parsed `Cmd`
+- the original `Protocol`
+- the existing `run(...)` path during replay
+
+In other words, transaction execution does not need a second execution engine. It re-enters the same command dispatch path with queueing turned off.
+
+## Replication interaction
+
+After successful command execution, `Cmd::run(...)` updates `server.offset` using the encoded protocol length. That gives the server a simple running notion of how much write traffic has flowed through the replication stream.
+
+## Current implementation limits
+
+- command parsing assumes well-formed array shapes for each supported command
+- unsupported commands collapse into `Unknow`
+- transaction queueing is connection-local and intentionally simple
+- stream and transaction behavior is implemented for learning clarity, not wire-compatibility depth
+
+That tradeoff is consistent across the repo: code paths are small and readable, while still exposing enough of Redis to make persistence, replication, streams, and transactions feel connected.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,64 @@
+---
+title: Docs Overview
+layout: default
+nav_exclude: true
+permalink: /docs/overview/
+---
+
+# Docs Overview
+
+[Homepage]({{ '/' | relative_url }}) | [Server Runtime]({{ '/docs/server-runtime/' | relative_url }}) | [RESP Protocol]({{ '/docs/resp-protocol/' | relative_url }}) | [Storage Model]({{ '/docs/storage-model/' | relative_url }})
+
+This docs area now maps `redis-rs` at module level instead of collapsing several ownership boundaries into three broad chapters.
+
+## Reading path
+
+Use this sequence if you want to understand the implementation from the outside in:
+
+1. runtime entry and shared server state
+2. RESP parsing and encoding
+3. string storage and stream containers
+4. RDB snapshot parsing
+5. replication handshake and fan-out
+6. command dispatch
+7. streams and transaction replay
+
+## Chapters
+
+- [Server Runtime]({{ '/docs/server-runtime/' | relative_url }})
+  - `src/main.rs`
+  - `src/server.rs`
+  - `src/options.rs`
+- [RESP Protocol]({{ '/docs/resp-protocol/' | relative_url }})
+  - `src/protocol.rs`
+- [Storage Model]({{ '/docs/storage-model/' | relative_url }})
+  - `src/storage.rs`
+  - `src/server.rs`
+- [RDB Parser]({{ '/docs/rdb-parser/' | relative_url }})
+  - `src/rdb.rs`
+- [Replication Flow]({{ '/docs/replication-flow/' | relative_url }})
+  - `src/main.rs`
+  - `src/replication_client.rs`
+  - `src/server.rs`
+  - `src/cmd.rs`
+- [Command Execution]({{ '/docs/command-execution/' | relative_url }})
+  - `src/cmd.rs`
+  - `src/server.rs`
+  - `src/protocol.rs`
+- [Streams and Transactions]({{ '/docs/streams-and-transactions/' | relative_url }})
+  - `src/cmd.rs`
+  - `src/server.rs`
+
+## Why this split
+
+The repository is compact, but the code still has more than three real implementation boundaries:
+
+- entry/runtime orchestration
+- RESP parsing
+- storage
+- RDB decoding
+- replication handshake and fan-out
+- command dispatch
+- stream and transaction extensions
+
+Keeping those boundaries visible makes the docs much closer to the source tree and much better for code reading.

--- a/docs/persistence-and-replication.md
+++ b/docs/persistence-and-replication.md
@@ -1,0 +1,110 @@
+---
+title: Persistence and Replication
+layout: default
+nav_exclude: true
+permalink: /docs/persistence-and-replication/
+---
+
+# Persistence and Replication
+
+This chapter covers how the project restores state from RDB files and how master/slave synchronization is wired.
+
+## File boundaries
+
+- `src/rdb.rs`
+- `src/replication_client.rs`
+- `src/server.rs`
+
+## RDB loading path
+
+The master startup path in `Server::init(...)` opens the configured DB file and only parses it when the file is non-empty.
+
+The load chain is:
+
+1. `Server::init(...)`
+2. `rdb::parse_rdb_file(...)`
+3. `rdb::parse_rdb(...)`
+
+The parser writes decoded values directly into `server.storage`.
+
+## What the RDB parser supports
+
+`src/rdb.rs` implements a focused subset of the Redis RDB format:
+
+- magic header validation
+- version read
+- auxiliary metadata sections
+- database selection markers
+- table size info
+- string keys with and without expiration
+- EOF marker and CRC read
+
+The code recognizes two expiration encodings:
+
+- `0xFC` for millisecond timestamps
+- `0xFD` for second timestamps
+
+When expiration exists, the parser converts the loaded timestamp into the `Storage::setx(...)` path.
+
+## String decoding model
+
+The parser supports these string encodings:
+
+- raw string
+- 8-bit integer
+- 16-bit integer
+- 32-bit integer
+
+LZF-compressed strings are explicitly not supported yet. That is surfaced as an error rather than silently ignored.
+
+## Storage interaction
+
+`src/storage.rs` is intentionally small:
+
+- `set(...)` stores plain values
+- `setx(...)` stores values with an absolute expiration timestamp
+- `get(...)` lazily deletes expired keys on read
+
+This is a simple model, but it keeps the persistence path easy to understand: the RDB loader only has to decide whether an entry has an expiry and then call the corresponding storage method.
+
+## Slave handshake flow
+
+`src/replication_client.rs` implements the follower-side startup sequence:
+
+1. `PING`
+2. `REPLCONF listening-port <port>`
+3. `REPLCONF capa psync2`
+4. `PSYNC ? -1`
+
+The implementation checks each expected response explicitly through `check_resp(...)`.
+
+## Full sync behavior
+
+After `PSYNC`, the follower reads:
+
+1. the `FULLRESYNC` line
+2. the `$<len>` RDB payload header
+3. the RDB payload itself
+
+The received snapshot is then parsed by reusing `rdb::parse_rdb(...)`.
+
+That reuse is important: there is one RDB decoding path for local file restore and replica bootstrap.
+
+## Master-side replication behavior
+
+When the master receives `PSYNC` inside `Server::handle(...)`:
+
+1. it sends the RDB payload through `MasterReplicationClient::send_rdb_file(...)`
+2. it stores the replica socket through `add_stream(...)`
+3. it stops treating that connection as a normal request/response client
+
+`MasterReplicationClient` then becomes the fan-out point for replicated write commands using `send_command(...)`.
+
+## Current implementation limits
+
+- the master sends a constant empty RDB seed payload before downstream command replay
+- RDB CRC is read but not validated
+- auxiliary metadata is parsed and ignored
+- replication state tracking is intentionally narrow compared with production Redis
+
+Those choices keep the project focused on the essential control flow: load state, establish role relationship, and start replaying write traffic.

--- a/docs/rdb-parser.md
+++ b/docs/rdb-parser.md
@@ -1,0 +1,149 @@
+---
+title: RDB Parser
+layout: default
+nav_order: 6
+permalink: /docs/rdb-parser/
+---
+
+# RDB Parser
+
+This chapter isolates the local snapshot parser from the rest of the persistence and replication story.
+
+## File boundary
+
+- `src/rdb.rs`
+
+## Role of the module
+
+`src/rdb.rs` does one job: turn an RDB byte stream into writes against `server.storage`.
+
+It is reused in two different contexts:
+
+- local startup restore from a DB file
+- replica bootstrap after downloading a snapshot from the master
+
+That reuse is one of the cleaner decisions in the repo. There is only one RDB decoding path.
+
+## Entry functions
+
+There are two entrypoints:
+
+- `parse_rdb_file(...)`
+- `parse_rdb(...)`
+
+`parse_rdb_file(...)` is a convenience wrapper that creates a `BufReader` over a file.
+
+`parse_rdb(...)` is the actual streaming parser and accepts any `AsyncRead + Unpin`, which is why replication can reuse it directly.
+
+## Overall control flow
+
+The parser starts by locking `server.storage`, then processes the stream in this order:
+
+1. `parse_magic(...)`
+2. `parse_version(...)`
+3. repeated opcode dispatch loop
+4. stop on `EOF`
+
+Inside the opcode loop, it recognizes:
+
+- `META`
+- `DB_SELECT`
+- `TABLE_SIZE_INFO`
+- `EOF`
+
+Anything else is treated as an error.
+
+## Header validation
+
+`parse_magic(...)` reads exactly five bytes and checks for `REDIS`.
+
+`parse_version(...)` then reads the next four bytes as the RDB version payload.
+
+The parser validates structure here, but does not interpret version-specific feature differences.
+
+## Metadata sections
+
+When it sees `META`, the parser calls `parse_aux(...)` twice and then discards the results.
+
+So metadata is syntactically parsed but semantically ignored.
+
+That is a deliberate simplification:
+
+- keep the parser aligned with real RDB structure
+- avoid building a metadata model the server does not yet use
+
+## Database selection and table sizes
+
+`DB_SELECT` is parsed and ignored because this project effectively uses one logical DB.
+
+`TABLE_SIZE_INFO` is more operationally important. It provides:
+
+- number of non-expiring entries
+- number of expiring entries
+
+The parser uses these counts to decide how many entries to read in each category.
+
+## Entry parsing
+
+There are two entry readers:
+
+- `parse_no_expire_entry(...)`
+- `parse_expire_entry(...)`
+
+Both currently assume string value type `0`.
+
+That means this parser is focused on string keys, not the full Redis type matrix.
+
+## Expiration decoding
+
+`parse_expire_entry(...)` supports two encodings:
+
+- `0xFC` -> 8-byte little-endian milliseconds
+- `0xFD` -> 4-byte little-endian seconds
+
+Second-based expiration is converted to milliseconds before being written into storage.
+
+This keeps the rest of the runtime on one time unit.
+
+## Length and string decoding
+
+`parse_len(...)` interprets Redis RDB length prefixes and returns:
+
+- decoded length
+- `StringEncoding`
+
+Supported string encodings are:
+
+- `Raw`
+- `I8`
+- `I16`
+- `I32`
+- `LZF`
+
+`parse_string(...)` can decode every variant above except `LZF`, which returns an explicit error.
+
+## Data flow into storage
+
+Once entries are parsed, they are written immediately:
+
+- non-expiring entry -> `storage.set(...)`
+- expiring entry -> `storage.setx(...)`
+
+The parser does not build an intermediate object graph. It streams values straight into runtime state.
+
+## CRC handling
+
+When `EOF` is reached, the parser reads an 8-byte CRC field and ignores it.
+
+So the file structure is consumed correctly, but checksum validation is not implemented.
+
+## Current implementation limits
+
+- only a narrow subset of the RDB format is supported
+- metadata is ignored
+- DB index is ignored
+- only string-type entries are handled
+- LZF strings are rejected
+- CRC is not validated
+
+Even with those limits, the parser is detailed enough to explain the real shape of Redis persistence and to power both local restore and replica bootstrap.

--- a/docs/replication-flow.md
+++ b/docs/replication-flow.md
@@ -1,0 +1,137 @@
+---
+title: Replication Flow
+layout: default
+nav_order: 7
+permalink: /docs/replication-flow/
+---
+
+# Replication Flow
+
+This chapter focuses on how master and slave nodes establish a relationship and exchange state.
+
+## File boundaries
+
+- `src/main.rs`
+- `src/replication_client.rs`
+- `src/server.rs`
+- `src/cmd.rs`
+
+## Replica startup path
+
+Slave startup begins in `main.rs`, not inside a hidden background service.
+
+The explicit sequence is:
+
+1. build `Server`
+2. create `FollowerReplicationClient`
+3. `ping_master()`
+4. `report_port(...)`
+5. `report_sync_protocol()`
+6. `start_psync(...)`
+7. spawn `Server::handle(...)` on the replication socket
+
+That makes replication easy to trace because the orchestration is all near the binary entrypoint.
+
+## Follower-side handshake
+
+`FollowerReplicationClient` drives the upstream handshake over a single `TcpStream`.
+
+The messages are:
+
+1. `PING`
+2. `REPLCONF listening-port <port>`
+3. `REPLCONF capa psync2`
+4. `PSYNC ? -1`
+
+Each step writes a RESP array and then validates the master's response through `check_resp(...)`.
+
+## `PSYNC` response handling
+
+`start_psync(...)` sends the command and immediately delegates to `recv_rdb_file(...)`.
+
+That method expects:
+
+1. one line containing replication metadata such as `FULLRESYNC <id> <offset>`
+2. a `$<len>` header for the snapshot payload
+3. the raw RDB payload
+
+The snapshot bytes are then parsed by reusing `rdb::parse_rdb(...)`.
+
+## Master-side `PSYNC` handling
+
+On the master, `PSYNC` is recognized in two places:
+
+- `Cmd::from(...)` maps the command into `Cmd::Psync`
+- `Server::handle(...)` special-cases that command after execution
+
+The runtime branch in `Server::handle(...)` does the critical work:
+
+1. call `send_rdb_file(...)`
+2. call `add_stream(...)`
+3. break out of the normal request loop
+
+At that point the socket becomes a registered replica downstream.
+
+## Why master behavior lives in `Server::handle(...)`
+
+The code treats `PSYNC` as both:
+
+- a logical command that returns `FULLRESYNC`
+- a connection-mode transition
+
+That second part cannot live entirely inside `cmd.rs`, because the server must keep the replica socket for future fan-out.
+
+So the control flow is intentionally split:
+
+- command semantics -> `psync_cmd(...)`
+- socket ownership transition -> `Server::handle(...)`
+
+## Snapshot payload source
+
+`MasterReplicationClient::send_rdb_file(...)` currently sends a constant hex-encoded empty RDB image.
+
+This is not a real serialization of live server state. It is a bootstrap seed that lets the protocol flow continue.
+
+That is one of the biggest fidelity gaps relative to production Redis.
+
+## Write propagation
+
+Once replicas are registered, write propagation goes through `MasterReplicationClient::send_command(...)`.
+
+The method:
+
+1. locks the list of replica streams
+2. iterates over each socket
+3. writes the encoded protocol to every replica
+
+This is a simple broadcast fan-out model with no per-replica backpressure logic.
+
+## How command execution triggers replication
+
+Write-like commands in `cmd.rs` eventually call `resp_and_replicate(...)`.
+
+That function behaves differently by role:
+
+- master -> send command to replicas, then return local response
+- slave on normal client connection -> reject writes
+- slave on replication connection -> accept replayed writes
+
+This is the module boundary where replication rules intersect with command semantics.
+
+## Offset tracking
+
+The server tracks a coarse replication offset in `server.offset`.
+
+Successful command execution increments it using the encoded protocol length. `REPLCONF GETACK` reads from that value to report progress.
+
+This is not a complete replication state machine, but it is enough to model the basic flow of acknowledged progress.
+
+## Current implementation limits
+
+- snapshot source is a constant empty RDB payload
+- no partial resync
+- no backlog window
+- no replica liveness tracking
+- no retry or reconnect loop beyond startup path
+
+Even so, the code shows the essential educational shape of leader-follower replication: handshake, full sync, socket registration, then downstream command replay.

--- a/docs/resp-protocol.md
+++ b/docs/resp-protocol.md
@@ -1,0 +1,160 @@
+---
+title: RESP Protocol
+layout: default
+nav_order: 4
+permalink: /docs/resp-protocol/
+---
+
+# RESP Protocol
+
+This chapter isolates the project's RESP model from the rest of the server logic.
+
+## File boundary
+
+- `src/protocol.rs`
+
+## Protocol enum
+
+`Protocol` is the internal representation used between parsing, command execution, and socket output.
+
+The enum currently supports:
+
+- `SimpleString(String)`
+- `BulkString(String)`
+- `Null`
+- `Array(Vec<Protocol>)`
+
+That is enough for the current command set and response surface.
+
+## Why this module matters
+
+Everything else in the project assumes a parsed `Protocol` value exists.
+
+Two especially important boundaries depend on it:
+
+- `Cmd::from(...)` consumes parsed arrays to decide which command was requested
+- `Protocol::encode(...)` turns command results back into bytes for clients and replicas
+
+So this module is both the inbound and outbound wire-format adapter.
+
+## Parsing entrypoint
+
+`Protocol::from(protocol: &str)` is the top-level parser.
+
+It inspects the first byte and dispatches to one of three suffix parsers:
+
+- `parse_simple_string_sfx(...)`
+- `parse_bulk_string_sfx(...)`
+- `parse_array_sfx(...)`
+
+It returns a pair:
+
+- parsed `Protocol`
+- consumed byte length
+
+That consumed length is what makes recursive array parsing possible.
+
+## Simple strings
+
+`parse_simple_string_sfx(...)` looks for the first `\\r\\n` pair and returns the bytes before it as a `SimpleString`.
+
+This is the simplest parser in the file:
+
+- no nested structure
+- no declared payload length
+- direct substring extraction
+
+## Bulk strings
+
+`parse_bulk_string_sfx(...)` has two stages:
+
+1. parse the declared string length before the first `\\r\\n`
+2. parse the following payload and verify its actual length matches the declared length
+
+If lengths disagree, the parser returns an error instead of trying to recover.
+
+## Important behavior: lowercasing payloads
+
+When a bulk string is accepted, the implementation stores it as:
+
+```rust
+Protocol::BulkString(s.to_lowercase())
+```
+
+This has a practical benefit and a semantic cost.
+
+Benefit:
+
+- command matching becomes case-insensitive with no extra logic in `Cmd::from(...)`
+
+Cost:
+
+- bulk string payloads do not preserve original casing
+- values are no longer byte-exact relative to the wire input
+
+This is acceptable for the repo's learning focus, but it is a real difference from production Redis behavior.
+
+## Arrays
+
+`parse_array_sfx(...)` first reads the array length prefix, then repeatedly calls `Protocol::from(...)` on the remaining suffix.
+
+Each child parse returns its own consumed length, and the parser advances an `offset` cursor until all array elements have been parsed.
+
+The data flow is:
+
+```text
+array header
+-> child 1 parse + length
+-> child 2 parse + length
+-> ...
+-> Protocol::Array(vec)
+```
+
+This is the only place where the length-returning parse API really pays off.
+
+## Construction helpers
+
+The file also exposes helpers used by higher layers:
+
+- `from_vec(...)`
+- `ok()`
+- `err(...)`
+- `write_on_slave_err()`
+- `psync_on_slave_err()`
+- `none()`
+
+These helpers keep command handlers from repeatedly rebuilding small RESP fragments by hand.
+
+## Encoding path
+
+`encode()` converts `Protocol` back into RESP text.
+
+The current mapping is:
+
+- `SimpleString` -> `+...\\r\\n`
+- `BulkString` -> `$len\\r\\npayload\\r\\n`
+- `Array` -> `*len\\r\\n` followed by encoded children
+- `Null` -> `$-1\\r\\n`
+
+This makes the same structure reusable for:
+
+- client responses
+- replication handshake messages
+- write propagation to replicas
+
+## Human-readable decoding
+
+`decode()` flattens a `Protocol` value into a plain string.
+
+This is used heavily by command parsing, especially when turning a parsed array into a vector of command tokens.
+
+For arrays, `decode()` joins child values with spaces. That is a convenient command-oriented representation, even though it is not a lossless structural rendering.
+
+## Current implementation limits
+
+- parser input is a Rust `&str`, not raw bytes
+- null bulk strings beyond the explicit `Null` encoding are not modeled separately
+- nested arrays are supported structurally, but the command layer only expects a narrow subset
+- bulk string lowercasing changes payload semantics
+
+The module is intentionally small, but it is still the core wire-format hinge of the repo.

--- a/docs/runtime-and-protocol.md
+++ b/docs/runtime-and-protocol.md
@@ -1,0 +1,124 @@
+---
+title: Runtime and Protocol
+layout: default
+nav_exclude: true
+permalink: /docs/runtime-and-protocol/
+---
+
+# Runtime and Protocol
+
+This chapter covers the runtime entrypoint, the TCP server loop, and the RESP parser that turns raw client bytes into executable commands.
+
+## File boundaries
+
+- `src/main.rs`
+- `src/server.rs`
+- `src/protocol.rs`
+- `src/options.rs`
+
+## Entry flow
+
+`src/main.rs` is the only executable entrypoint. It parses four CLI inputs:
+
+- `--dir`
+- `--dbfilename`
+- `--port`
+- `--replicaof`
+
+Those values are assembled into `DBOption` and `ReplicationOption` from `src/options.rs`, then passed into `Server::new(...)`.
+
+The important consequence is that role selection is entirely CLI-driven. If `--replicaof` is present, the server starts in slave mode; otherwise it starts as master.
+
+## Listener model
+
+The server binds one Tokio `TcpListener` to `127.0.0.1:<port>`.
+
+For each accepted socket:
+
+1. clone the `Server`
+2. spawn a Tokio task
+3. hand the socket to `Server::handle(...)`
+
+This means the implementation uses a shared logical server with per-connection async tasks rather than a single-threaded command loop.
+
+## Shared server state
+
+`src/server.rs` stores the shared runtime in `Server`:
+
+- `storage`: key-value state protected by `Arc<Mutex<Storage>>`
+- `streams`: stream data protected by `Arc<Mutex<HashMap<...>>>`
+- `option`: runtime configuration
+- `offset`: replication offset via `AtomicU64`
+- `master_repl_clients`: replica downstream connections when running as master
+- `stream_reader_blocker`: async blockers used by blocking stream reads
+
+The storage and stream maps are protected independently, which keeps ordinary string operations and stream operations from sharing the same mutex.
+
+## Connection handling
+
+`Server::handle(...)` performs a read-decode-execute loop:
+
+1. read bytes into a fixed buffer
+2. decode the buffer as UTF-8
+3. call `Cmd::from(...)`
+4. execute `cmd.run(...)`
+5. write a response unless the connection is a replication channel
+
+The current implementation assumes a single decoded command per read buffer and uses a fixed `512` byte buffer. That keeps the code short, but it also means protocol framing is simpler than a production Redis implementation.
+
+## RESP implementation
+
+`src/protocol.rs` defines a small `Protocol` enum:
+
+- `SimpleString`
+- `BulkString`
+- `Null`
+- `Array`
+
+The parser supports:
+
+- simple strings starting with `+`
+- bulk strings starting with `$`
+- arrays starting with `*`
+
+`Protocol::from(...)` returns both the parsed value and consumed byte length, which is then reused by array parsing.
+
+## Important behavior in this parser
+
+### Lowercasing bulk strings
+
+`parse_bulk_string_sfx(...)` lowercases the decoded bulk string before storing it in `Protocol::BulkString`.
+
+That means command tokens and bulk string payloads are normalized the same way. It simplifies command dispatch, but it also means this parser does not preserve original case for bulk string values.
+
+### Encoding helpers
+
+The module provides helpers used broadly across the server:
+
+- `Protocol::ok()`
+- `Protocol::err(...)`
+- `Protocol::none()`
+- `encode()`
+- `decode()`
+
+These helpers are the common boundary between command execution and socket I/O.
+
+## Role-specific startup
+
+If the server starts as slave:
+
+1. it creates a `FollowerReplicationClient`
+2. it performs the replication handshake
+3. it loads the initial RDB state from the master
+4. it spawns another handler task for the replication connection itself
+
+That startup sequence is still driven from `main.rs`, not hidden inside `Server::new(...)`, so the high-level control flow is easy to trace from the executable entrypoint.
+
+## Current implementation limits
+
+- fixed socket read buffer size
+- UTF-8 assumption over the full incoming chunk
+- no incremental request framing across partial reads
+- protocol parser is intentionally small and command-oriented rather than fully general
+
+These limits fit the repo's educational purpose: the code stays readable while still exposing the essential Redis request lifecycle.

--- a/docs/server-runtime.md
+++ b/docs/server-runtime.md
@@ -1,0 +1,164 @@
+---
+title: Server Runtime
+layout: default
+nav_order: 3
+permalink: /docs/server-runtime/
+---
+
+# Server Runtime
+
+This chapter follows the executable entrypoint and the shared server object that every connection task clones.
+
+## File boundaries
+
+- `src/main.rs`
+- `src/server.rs`
+- `src/options.rs`
+
+## What starts the process
+
+`src/main.rs` is the only binary entrypoint. It parses four command-line arguments:
+
+- `--dir`
+- `--dbfilename`
+- `--port`
+- `--replicaof`
+
+Those inputs are assembled into `DBOption` and `ReplicationOption`, then passed into `Server::new(...)`.
+
+This means process role is selected before the server exists:
+
+- no `--replicaof` -> master
+- with `--replicaof` -> slave
+
+## Configuration model
+
+`src/options.rs` keeps runtime configuration deliberately small.
+
+`DBOption` carries:
+
+- DB directory
+- DB filename
+- TCP port
+- replication settings
+
+`ReplicationOption` carries:
+
+- `role`
+- `master_replid`
+- `master_repl_offset`
+- `replica_of`
+
+The server never discovers its role dynamically. It trusts the CLI-derived option object.
+
+## Listener and task model
+
+After parsing arguments, `main.rs` binds one Tokio `TcpListener` on `127.0.0.1:<port>`.
+
+For each accepted connection, it:
+
+1. clones `Server`
+2. spawns a Tokio task
+3. calls `Server::handle(...)`
+
+This gives the project a simple concurrency model:
+
+- one logical shared server state
+- one async task per socket
+- no central command scheduler
+
+## What `Server` stores
+
+`Server` in `src/server.rs` is the shared runtime shell. The important fields are:
+
+- `storage: Arc<Mutex<Storage>>`
+- `streams: Arc<Mutex<HashMap<String, Stream>>>`
+- `option: DBOption`
+- `offset: Arc<AtomicU64>`
+- `master_repl_clients: Arc<Mutex<Option<MasterReplicationClient>>>`
+- `stream_reader_blocker: Arc<Mutex<Vec<Sender<()>>>>`
+- `master_addr: Option<String>`
+
+The separation between `storage` and `streams` is meaningful: string keys and stream keys do not contend on the same mutex.
+
+## Startup path in `Server::new(...)`
+
+`Server::new(...)` does three high-level things:
+
+1. derives `master_addr` if the node is configured as a slave
+2. allocates shared state containers
+3. calls `init().await`
+
+Master-only replication fan-out state is also allocated here. If the node is a slave, `master_repl_clients` is `None`.
+
+## Master-side initialization
+
+`Server::init(...)` currently performs only master-side local persistence bootstrap.
+
+The control flow is:
+
+1. construct DB file path from `dir` and `db_file_name`
+2. create the file if it does not exist
+3. check file length
+4. if non-empty, parse it through `rdb::parse_rdb_file(...)`
+
+Slave nodes skip this branch because their initial state is expected to come from the upstream master during replication bootstrap.
+
+## Slave-side startup path
+
+Slave-specific startup is not hidden inside `Server::new(...)`; it remains visible in `main.rs`.
+
+The sequence is:
+
+1. create a follower replication client with `get_follower_repl_client(...)`
+2. `PING` master
+3. report listening port
+4. report sync capability
+5. start `PSYNC`
+6. spawn a dedicated handler task for the replication socket
+
+This keeps the top-level runtime easy to trace from the binary entrypoint.
+
+## The connection loop
+
+`Server::handle(...)` is the per-socket runtime loop.
+
+For each iteration it:
+
+1. reads into a fixed `512` byte buffer
+2. converts bytes into UTF-8 text
+3. parses one command with `Cmd::from(...)`
+4. executes it through `cmd.run(...)`
+5. writes a response unless the socket is a replication connection
+
+If the node is master and the command is `PSYNC`, it switches behavior:
+
+1. send RDB payload
+2. register the socket as a replica downstream
+3. stop normal request/response handling for that connection
+
+That branch is the runtime hinge between ordinary clients and replication clients.
+
+## Data flow through a normal request
+
+For a normal client connection the data path is:
+
+```text
+socket bytes
+-> Server::handle
+-> Cmd::from
+-> Cmd::run
+-> Protocol response
+-> socket write
+```
+
+The server object itself stays mostly orchestration-oriented. It does not implement command semantics directly.
+
+## Current implementation limits
+
+- one fixed-size read buffer per connection
+- one parsed command per successful read
+- no incremental framing across partial reads
+- no explicit shutdown or task supervision structure
+
+Those tradeoffs keep the runtime surface compact enough to read in one pass.

--- a/docs/storage-model.md
+++ b/docs/storage-model.md
@@ -1,0 +1,133 @@
+---
+title: Storage Model
+layout: default
+nav_order: 5
+permalink: /docs/storage-model/
+---
+
+# Storage Model
+
+This chapter covers the in-memory key-value storage layer and the stream container shape that sits beside it.
+
+## File boundaries
+
+- `src/storage.rs`
+- `src/server.rs`
+
+## String key-value storage
+
+`src/storage.rs` defines the core storage type used for normal Redis string commands.
+
+The internal representation is:
+
+```text
+HashMap<String, (String, Option<u128>)>
+```
+
+Each entry stores:
+
+- the string value
+- an optional absolute expiration timestamp in milliseconds
+
+The type alias `ValueType` makes that tuple explicit in the code.
+
+## Why expiration is stored as an absolute timestamp
+
+The storage layer does not keep:
+
+- insertion time
+- relative TTL duration
+
+Instead, it stores an absolute expiration timestamp. That decision keeps reads simple:
+
+- compare `now_in_millis()` with stored timestamp
+- remove expired key if needed
+- otherwise return the value
+
+This matches the needs of both direct `SET PX/EX` writes and RDB restore.
+
+## `now_in_millis()`
+
+`now_in_millis()` is the time source for expiry behavior. It converts `SystemTime` into Unix milliseconds.
+
+That helper is reused in two places:
+
+- storage expiry checks
+- auto-generated stream IDs in `cmd.rs`
+
+So the project already treats millisecond time as a shared primitive across multiple subsystems.
+
+## Read path
+
+`Storage::get(...)` is more than a plain lookup.
+
+The control flow is:
+
+1. look up key in `HashMap`
+2. if key has an expiration timestamp, compare it with current time
+3. if expired, delete the key and return `None`
+4. otherwise clone and return the stored string
+
+This is lazy expiration. Expired keys disappear when accessed, not through a background eviction loop.
+
+## Write paths
+
+The write surface is intentionally narrow:
+
+- `set(...)` -> store value without expiry
+- `setx(...)` -> store value with expiry
+- `del(...)` -> remove key
+- `keys(...)` -> list current keys
+
+`setx(...)` converts the provided relative TTL into an absolute timestamp by adding `now_in_millis()`.
+
+That means callers do not need to share a common time conversion policy. They only need to provide a duration in milliseconds.
+
+## What is not stored here
+
+Streams are not part of `Storage`.
+
+Instead, `Server` keeps a second container:
+
+```text
+HashMap<String, BTreeMap<String, Vec<(String, String)>>>
+```
+
+That separation matters because:
+
+- string keys have optional expiry and simple point lookups
+- stream keys need ordered range queries by entry ID
+
+Using `BTreeMap` for streams gives ordered traversal without complicating the ordinary string-key storage model.
+
+## How command handlers interact with storage
+
+Command helpers in `cmd.rs` typically access storage like this:
+
+1. lock `server.storage`
+2. call one storage method
+3. release lock
+
+Because `Storage` itself is synchronous and small, the async boundary lives outside it in the server's `Mutex`.
+
+## Data flow for string commands
+
+For commands such as `GET`, `SET`, `DEL`, and `INCR`, the data path is:
+
+```text
+command helper in cmd.rs
+-> lock server.storage
+-> call Storage method
+-> build Protocol response
+```
+
+This is one reason the repo stays readable: command helpers remain thin adapters over a tiny storage core.
+
+## Current implementation limits
+
+- all values are stored as strings
+- expiration cleanup is lazy, not proactive
+- there is no size accounting or eviction policy
+- `keys()` does not filter expired entries unless they were previously touched by `get()`
+
+Those tradeoffs are reasonable for a teaching implementation and make the storage layer easy to inspect.

--- a/docs/streams-and-transactions.md
+++ b/docs/streams-and-transactions.md
@@ -1,0 +1,154 @@
+---
+title: Streams and Transactions
+layout: default
+nav_order: 9
+permalink: /docs/streams-and-transactions/
+---
+
+# Streams and Transactions
+
+This chapter zooms in on the two higher-level behaviors that extend the basic string command set: streams and transactional queueing.
+
+## File boundaries
+
+- `src/cmd.rs`
+- `src/server.rs`
+
+## Stream storage shape
+
+Streams live in `Server::streams`, not in `Storage`.
+
+The type alias is:
+
+```text
+BTreeMap<String, Vec<(String, String)>>
+```
+
+and the full container is:
+
+```text
+HashMap<String, Stream>
+```
+
+That means:
+
+- top-level key -> stream name
+- ordered map key -> entry id
+- value -> list of field/value pairs
+
+The use of `BTreeMap` is what makes range queries possible without an extra ordering index.
+
+## Stream ID parsing
+
+`split_offset(...)` is the low-level helper behind stream IDs.
+
+It extracts three pieces of information:
+
+- millisecond timestamp part
+- sequence part
+- whether the ID used a wildcard sequence
+
+This helper is reused by both writes and reads, so stream ordering logic stays in one place.
+
+## `XADD`
+
+`xadd_cmd(...)` handles stream writes.
+
+Its control flow is:
+
+1. normalize `*` into `now_in_millis()-*`
+2. split the incoming ID
+3. reject invalid `0-0`
+4. compare against current stream tail if one exists
+5. resolve wildcard sequence when needed
+6. insert field/value pairs into the target stream entry
+7. wake any blocked readers
+8. replicate the original command if needed
+
+This is the densest stream command because it owns both ID validation and append semantics.
+
+## `XRANGE`
+
+`xrange_cmd(...)` converts the special Redis range sentinels:
+
+- `-` -> start from zero
+- `+` -> end at max
+
+It then performs a `BTreeMap::range(...)` query and serializes the results back into a flat RESP array.
+
+So the read path is effectively:
+
+```text
+stream key
+-> BTreeMap range
+-> iterate ordered entries
+-> encode as Protocol::Array
+```
+
+## `XREAD`
+
+`xread_cmd(...)` supports:
+
+- multiple streams
+- per-stream starting offsets
+- optional blocking mode
+
+For blocking behavior there are two branches:
+
+- positive `BLOCK <millis>` -> sleep for that duration
+- `BLOCK 0` -> register a wake-up sender and wait for notification
+
+The second branch uses `server.stream_reader_blocker` as a lightweight waiter registry.
+
+## Reader wake-up model
+
+After `XADD`, the code acquires `stream_reader_blocker`, sends one empty signal to each waiting reader, then clears the list.
+
+This is intentionally simple:
+
+- no per-stream wait queues
+- no fairness logic
+- one global wake-up list
+
+It is good enough to demonstrate blocking reads without introducing a larger async coordination subsystem.
+
+## Transaction queue model
+
+Transactions are represented by:
+
+```text
+Option<Vec<(Cmd, Protocol)>>
+```
+
+This queue is local to one connection inside `Server::handle(...)`.
+
+The important consequence is that transaction state does not live in the global server object. It belongs to the current client session.
+
+## `MULTI`, `EXEC`, `DISCARD`
+
+The transaction control flow is:
+
+- `MULTI` -> initialize empty queue
+- ordinary commands while queue exists -> push `(Cmd, Protocol)` and return `QUEUED`
+- `EXEC` -> replay queued commands through `cmd.run(...)`
+- `DISCARD` -> drop queue
+
+`exec_cmd(...)` is compact because it does not implement special transaction-only semantics. It just reuses the existing execution path with queueing disabled.
+
+## Why transaction replay stores both `Cmd` and `Protocol`
+
+The queue keeps both forms because they serve different purposes:
+
+- `Cmd` is the parsed semantic form used for dispatch
+- `Protocol` is still useful for replication and offset accounting
+
+That pairing avoids reparsing commands during replay.
+
+## Current implementation limits
+
+- stream waiters are global rather than per stream key
+- `BLOCK <millis>` uses sleep instead of wake-on-event-with-timeout
+- transaction queueing is connection-local and non-persistent
+- stream and transaction semantics are narrower than real Redis edge cases
+
+Even so, these features are implemented in a way that remains easy to follow from source.

--- a/docs/superpowers/plans/2026-06-17-github-pages-homepage.md
+++ b/docs/superpowers/plans/2026-06-17-github-pages-homepage.md
@@ -1,0 +1,1161 @@
+# GitHub Pages Homepage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a bilingual, GitHub Pages-ready homepage for `redis-rs` with English default, Chinese toggle, and a strong project-focused landing experience while preserving access to the existing documentation overview.
+
+**Architecture:** Reuse the repository's existing root-level Jekyll Pages pipeline. Replace the current root route with a custom homepage assembled from static HTML, CSS, and small vanilla JavaScript, and move the current markdown overview to a secondary page so the old documentation entry remains available.
+
+**Tech Stack:** Jekyll 4, Just the Docs theme, static HTML, CSS, vanilla JavaScript
+
+---
+
+## File Structure
+
+- Modify: `.gitignore`
+  - Ignore `.superpowers/` generated during design work.
+- Create: `index.html`
+  - New root GitHub Pages homepage with semantic sections and `data-i18n` hooks.
+- Create: `assets/css/homepage.css`
+  - Homepage-only visual design, layout, responsiveness, and motion.
+- Create: `assets/js/homepage.js`
+  - Translation dictionary, default-English rendering, toggle handling, and optional persistence.
+- Modify: `index.md`
+  - Convert the existing overview page into a non-root documentation page with a new permalink and nav metadata.
+- Modify: `_config.yml`
+  - Point auxiliary GitHub link to the real repository and keep the site metadata coherent with the new homepage.
+- Verify: local Jekyll output via `bundle exec jekyll build`
+  - Confirms the homepage works inside the actual Pages pipeline.
+
+### Task 1: Align the existing Pages entry points
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `index.md`
+- Modify: `_config.yml`
+
+- [ ] **Step 1: Write the failing verification target**
+
+Document the expected post-change behavior before editing:
+
+```text
+Root route `/redis-rs/` should render the new custom homepage.
+The existing markdown overview content should remain reachable from a secondary route.
+The site-level GitHub link should point to https://github.com/fangpin/redis-rs.
+```
+
+- [ ] **Step 2: Inspect the current root entry files**
+
+Run: `sed -n '1,120p' index.md && printf '\n---\n' && sed -n '1,120p' _config.yml && printf '\n---\n' && sed -n '1,120p' .gitignore`
+
+Expected: current root route is driven by `index.md`, site theme is Jekyll/Just the Docs, and `.superpowers/` is not yet ignored.
+
+- [ ] **Step 3: Update `.gitignore` minimally**
+
+Add this line at the end of `.gitignore`:
+
+```gitignore
+.superpowers/
+```
+
+- [ ] **Step 4: Move the existing overview page off the root route**
+
+Update `index.md` frontmatter from:
+
+```md
+---
+title: 概览
+layout: default
+nav_order: 1
+---
+```
+
+to:
+
+```md
+---
+title: 概览
+layout: default
+nav_order: 2
+permalink: /overview/
+---
+```
+
+Keep the existing markdown body content unchanged.
+
+- [ ] **Step 5: Correct the site-level GitHub link**
+
+Update `_config.yml` from:
+
+```yml
+aux_links:
+  GitHub: https://fangpin.github.io/redis-rs
+```
+
+to:
+
+```yml
+aux_links:
+  GitHub: https://github.com/fangpin/redis-rs
+```
+
+- [ ] **Step 6: Run a targeted verification pass**
+
+Run: `sed -n '1,20p' index.md && printf '\n---\n' && rg -n "^\\.superpowers/$|^aux_links:|GitHub:" _config.yml .gitignore`
+
+Expected:
+- `index.md` shows `permalink: /overview/`
+- `.gitignore` includes `.superpowers/`
+- `_config.yml` points GitHub to the repository URL
+
+- [ ] **Step 7: Commit the routing-alignment changes**
+
+```bash
+git add .gitignore _config.yml index.md
+git commit -m "chore: prepare pages routing for homepage"
+```
+
+### Task 2: Create the homepage markup
+
+**Files:**
+- Create: `index.html`
+
+- [ ] **Step 1: Write the failing structural expectation**
+
+Document the required homepage sections:
+
+```text
+The root homepage must contain:
+- hero
+- capability modules
+- quick start
+- architecture strip
+- repository/docs CTA
+- language toggle with EN default
+```
+
+- [ ] **Step 2: Verify that `index.html` does not already exist**
+
+Run: `test -f index.html; echo $?`
+
+Expected: `1`
+
+- [ ] **Step 3: Create the semantic homepage skeleton**
+
+Create `index.html` with this structure:
+
+```html
+---
+layout: nil
+title: redis-rs
+permalink: /
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>redis-rs | Build Your Own Redis in Rust</title>
+    <meta
+      name="description"
+      content="A Redis clone in Rust with RESP parsing, RDB loading, replication, streams, and transactions."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=Manrope:wght@400;500;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{{ '/assets/css/homepage.css' | relative_url }}" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="hero" id="top">
+        <nav class="topbar" aria-label="Primary">
+          <a class="brand" href="#top">redis-rs</a>
+          <div class="topbar-actions">
+            <a class="text-link" href="{{ '/overview/' | relative_url }}" data-i18n="nav.overview">Overview</a>
+            <a class="text-link" href="https://github.com/fangpin/redis-rs" target="_blank" rel="noreferrer" data-i18n="nav.github">GitHub</a>
+            <div class="language-toggle" role="group" aria-label="Language switcher">
+              <button class="lang-btn is-active" type="button" data-lang="en">EN</button>
+              <button class="lang-btn" type="button" data-lang="zh">中文</button>
+            </div>
+          </div>
+        </nav>
+
+        <section class="hero-content">
+          <div class="hero-copy">
+            <p class="eyebrow" data-i18n="hero.eyebrow">Protocol. Persistence. Replication.</p>
+            <h1 data-i18n="hero.title">Build Your Own Redis in Rust</h1>
+            <p class="hero-description" data-i18n="hero.description">
+              A toy Redis server in Rust that parses RESP, restores from RDB, replicates leader-follower state, supports streams, and queues transactional commands.
+            </p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="https://github.com/fangpin/redis-rs" target="_blank" rel="noreferrer" data-i18n="hero.primaryCta">View on GitHub</a>
+              <a class="button button-secondary" href="#quickstart" data-i18n="hero.secondaryCta">Quick Start</a>
+            </div>
+          </div>
+
+          <div class="hero-panel" aria-hidden="true">
+            <div class="panel-surface">
+              <div class="panel-header">
+                <span>runtime.signal</span>
+                <span>redis-rs</span>
+              </div>
+              <div class="panel-grid">
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.protocol">Protocol</span>
+                  <strong>RESP</strong>
+                </div>
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.persistence">Persistence</span>
+                  <strong>RDB</strong>
+                </div>
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.replication">Replication</span>
+                  <strong>PSYNC</strong>
+                </div>
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.streams">Queues</span>
+                  <strong>XREAD</strong>
+                </div>
+              </div>
+              <pre class="signal-code"><code>cargo run -- --dir ./db --dbfilename dump.rdb
+redis-cli PING
+redis-cli INFO replication
+redis-cli XADD stream_key "*" foo bar</code></pre>
+            </div>
+          </div>
+        </section>
+      </header>
+
+      <main>
+        <section class="section capability-section" id="capabilities">
+          <div class="section-heading">
+            <p class="eyebrow" data-i18n="capabilities.eyebrow">Core capabilities</p>
+            <h2 data-i18n="capabilities.title">Built around real Redis subsystems</h2>
+          </div>
+          <div class="capability-grid">
+            <article class="capability-card">
+              <p class="card-kicker">01</p>
+              <h3 data-i18n="capabilities.protocol.title">Protocol</h3>
+              <p data-i18n="capabilities.protocol.body">Parses Redis protocol messages and routes commands through the server runtime.</p>
+              <span class="chip">protocol.rs</span>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">02</p>
+              <h3 data-i18n="capabilities.persistence.title">Persistence</h3>
+              <p data-i18n="capabilities.persistence.body">Loads database state from RDB files and restores key metadata.</p>
+              <span class="chip">rdb.rs</span>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">03</p>
+              <h3 data-i18n="capabilities.replication.title">Replication</h3>
+              <p data-i18n="capabilities.replication.body">Bootstraps replica handshake, full sync, and replicated write flow.</p>
+              <span class="chip">replication_client.rs</span>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">04</p>
+              <h3 data-i18n="capabilities.streams.title">Streams and transactions</h3>
+              <p data-i18n="capabilities.streams.body">Supports stream operations and queued transactional execution patterns.</p>
+              <span class="chip">cmd.rs</span>
+            </article>
+          </div>
+        </section>
+
+        <section class="section quickstart-section" id="quickstart">
+          <div class="section-heading">
+            <p class="eyebrow" data-i18n="quickstart.eyebrow">Run it</p>
+            <h2 data-i18n="quickstart.title">Start fast, then probe with redis-cli</h2>
+          </div>
+          <div class="command-deck">
+            <div class="command-card">
+              <div class="command-label" data-i18n="quickstart.masterLabel">Master</div>
+              <pre><code>cargo run -- --dir /some/db/path --dbfilename dump.rdb</code></pre>
+            </div>
+            <div class="command-card">
+              <div class="command-label" data-i18n="quickstart.replicaLabel">Replica</div>
+              <pre><code>cargo run -- --dir /some/db/path --dbfilename dump.rdb --port 6380 --replicaof "localhost 6379"</code></pre>
+            </div>
+            <div class="command-card command-card-wide">
+              <div class="command-label" data-i18n="quickstart.probeLabel">Probe</div>
+              <pre><code>redis-cli PING
+redis-cli SET foo bar
+redis-cli INFO replication
+redis-cli XREAD block 0 streams some_key 1526985054069-0</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <section class="section architecture-section" id="architecture">
+          <div class="section-heading">
+            <p class="eyebrow" data-i18n="architecture.eyebrow">Implementation map</p>
+            <h2 data-i18n="architecture.title">How the runtime is assembled</h2>
+          </div>
+          <div class="architecture-strip">
+            <article class="architecture-node">
+              <span class="node-file">protocol.rs</span>
+              <h3 data-i18n="architecture.protocol.title">Protocol ingestion</h3>
+              <p data-i18n="architecture.protocol.body">RESP parsing and request framing for incoming client and replication traffic.</p>
+            </article>
+            <article class="architecture-node">
+              <span class="node-file">server.rs + cmd.rs</span>
+              <h3 data-i18n="architecture.command.title">Command routing</h3>
+              <p data-i18n="architecture.command.body">Connection handling, command dispatch, and transaction orchestration.</p>
+            </article>
+            <article class="architecture-node">
+              <span class="node-file">storage.rs + rdb.rs</span>
+              <h3 data-i18n="architecture.storage.title">State and restore</h3>
+              <p data-i18n="architecture.storage.body">In-memory storage backed by RDB parsing and initial database hydration.</p>
+            </article>
+            <article class="architecture-node">
+              <span class="node-file">replication_client.rs</span>
+              <h3 data-i18n="architecture.replication.title">Replication flow</h3>
+              <p data-i18n="architecture.replication.body">Replica-side handshake, sync start, and downstream command consumption.</p>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="section footer-cta">
+        <div>
+          <p class="eyebrow" data-i18n="footer.eyebrow">Source and docs</p>
+          <h2 data-i18n="footer.title">Inspect the code, then dive deeper</h2>
+        </div>
+        <div class="footer-actions">
+          <a class="button button-primary" href="https://github.com/fangpin/redis-rs" target="_blank" rel="noreferrer" data-i18n="footer.github">Open GitHub Repository</a>
+          <a class="button button-secondary" href="{{ '/README.html' | relative_url }}" data-i18n="footer.readmeEn">Read README</a>
+          <a class="button button-secondary" href="{{ '/README_CN.html' | relative_url }}" data-i18n="footer.readmeZh">Read Chinese README</a>
+        </div>
+      </footer>
+    </div>
+
+    <script src="{{ '/assets/js/homepage.js' | relative_url }}"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 4: Verify the root page structure exists**
+
+Run: `rg -n "data-i18n|hero|capability-grid|quickstart|architecture-strip|language-toggle" index.html`
+
+Expected: all major homepage sections and translation hooks are present.
+
+- [ ] **Step 5: Commit the homepage markup**
+
+```bash
+git add index.html
+git commit -m "feat: add homepage markup"
+```
+
+### Task 3: Implement the homepage styling
+
+**Files:**
+- Create: `assets/css/homepage.css`
+
+- [ ] **Step 1: Write the failing visual expectation**
+
+Document what the CSS must establish:
+
+```text
+The homepage should render with:
+- dark cyber technical palette
+- stable responsive layout
+- visually distinct hero, capability, quickstart, architecture, and footer sections
+- readable command blocks and buttons
+```
+
+- [ ] **Step 2: Verify the stylesheet does not already exist**
+
+Run: `test -f assets/css/homepage.css; echo $?`
+
+Expected: `1`
+
+- [ ] **Step 3: Create the stylesheet**
+
+Create `assets/css/homepage.css` with this content:
+
+```css
+:root {
+  color-scheme: dark;
+  --bg: #07111f;
+  --bg-elevated: rgba(11, 24, 41, 0.8);
+  --bg-panel: rgba(10, 20, 34, 0.92);
+  --line: rgba(122, 238, 255, 0.18);
+  --line-strong: rgba(122, 238, 255, 0.38);
+  --text: #ecf7ff;
+  --text-dim: rgba(236, 247, 255, 0.72);
+  --accent: #79f0ff;
+  --accent-strong: #9dffb8;
+  --accent-deep: #163250;
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  --radius: 20px;
+  --content-width: 1180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at top left, rgba(121, 240, 255, 0.18), transparent 28%),
+    radial-gradient(circle at 85% 10%, rgba(157, 255, 184, 0.12), transparent 18%),
+    linear-gradient(180deg, #050b14, #091426 45%, #07111f 100%);
+  color: var(--text);
+  font-family: "Manrope", system-ui, sans-serif;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(121, 240, 255, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(121, 240, 255, 0.05) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(180deg, rgba(255, 255, 255, 0.45), transparent 82%);
+}
+
+.page-shell {
+  width: min(calc(100% - 32px), var(--content-width));
+  margin: 0 auto;
+  padding: 24px 0 56px;
+}
+
+.hero,
+.section,
+.footer-cta {
+  position: relative;
+}
+
+.topbar,
+.hero-content,
+.section,
+.footer-cta {
+  backdrop-filter: blur(18px);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(6, 14, 25, 0.7);
+}
+
+.brand,
+.text-link,
+.button {
+  text-decoration: none;
+}
+
+.brand {
+  color: var(--text);
+  font-family: "Chakra Petch", sans-serif;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.text-link {
+  color: var(--text-dim);
+  font-size: 0.95rem;
+}
+
+.language-toggle {
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.lang-btn {
+  border: 0;
+  min-width: 60px;
+  padding: 9px 14px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  cursor: pointer;
+}
+
+.lang-btn.is-active {
+  background: linear-gradient(135deg, rgba(121, 240, 255, 0.22), rgba(157, 255, 184, 0.18));
+  color: var(--text);
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 28px;
+  margin-top: 20px;
+  padding: 36px;
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background:
+    linear-gradient(145deg, rgba(8, 21, 36, 0.96), rgba(8, 17, 31, 0.86)),
+    radial-gradient(circle at top right, rgba(121, 240, 255, 0.12), transparent 26%);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.eyebrow,
+.card-kicker,
+.command-label,
+.node-file,
+.metric-label {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  margin: 0 0 16px;
+  color: var(--accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1 {
+  max-width: 10ch;
+  font-family: "Chakra Petch", sans-serif;
+  font-size: clamp(3rem, 7vw, 5.8rem);
+  line-height: 0.95;
+}
+
+.hero-description {
+  margin-top: 18px;
+  max-width: 58ch;
+  color: var(--text-dim);
+  font-size: 1.04rem;
+  line-height: 1.75;
+}
+
+.hero-actions,
+.footer-actions {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.hero-actions {
+  margin-top: 28px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 18px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.button:hover,
+.lang-btn:hover,
+.text-link:hover {
+  transform: translateY(-1px);
+}
+
+.button-primary {
+  background: linear-gradient(135deg, rgba(121, 240, 255, 0.2), rgba(157, 255, 184, 0.22));
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.button-secondary {
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text);
+  border-color: var(--line);
+}
+
+.hero-panel {
+  display: flex;
+  align-items: stretch;
+}
+
+.panel-surface {
+  width: 100%;
+  min-height: 100%;
+  padding: 22px;
+  border: 1px solid rgba(121, 240, 255, 0.18);
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, rgba(8, 18, 30, 0.94), rgba(12, 29, 46, 0.88)),
+    radial-gradient(circle at top left, rgba(121, 240, 255, 0.08), transparent 30%);
+}
+
+.panel-header,
+.panel-grid,
+.signal-code,
+.capability-grid,
+.command-deck,
+.architecture-strip {
+  display: grid;
+}
+
+.panel-header {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  color: var(--text-dim);
+  font-size: 0.78rem;
+}
+
+.panel-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.metric,
+.capability-card,
+.command-card,
+.architecture-node,
+.footer-cta {
+  border: 1px solid var(--line);
+  background: var(--bg-elevated);
+}
+
+.metric {
+  padding: 14px;
+  border-radius: 16px;
+}
+
+.metric strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.35rem;
+}
+
+.signal-code {
+  margin-top: 18px;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(4, 10, 18, 0.92);
+  color: #b8ffe0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.88rem;
+  line-height: 1.7;
+  overflow: auto;
+}
+
+.section,
+.footer-cta {
+  margin-top: 24px;
+  padding: 28px;
+  border-radius: 26px;
+  background: rgba(6, 15, 27, 0.72);
+}
+
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.section-heading h2,
+.footer-cta h2 {
+  max-width: 22ch;
+  font-family: "Chakra Petch", sans-serif;
+  font-size: clamp(1.8rem, 3vw, 2.9rem);
+  line-height: 1.02;
+}
+
+.capability-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.capability-card,
+.architecture-node {
+  padding: 20px;
+  border-radius: 18px;
+}
+
+.card-kicker,
+.command-label,
+.node-file,
+.metric-label {
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.capability-card h3,
+.architecture-node h3 {
+  margin-top: 14px;
+  font-size: 1.18rem;
+}
+
+.capability-card p,
+.architecture-node p {
+  margin-top: 10px;
+  color: var(--text-dim);
+  line-height: 1.65;
+}
+
+.chip {
+  display: inline-flex;
+  margin-top: 14px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: rgba(121, 240, 255, 0.08);
+  color: var(--text);
+  font-size: 0.82rem;
+}
+
+.command-deck {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.command-card {
+  padding: 18px;
+  border-radius: 18px;
+}
+
+.command-card-wide {
+  grid-column: 1 / -1;
+}
+
+.command-card pre,
+.command-card code {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.command-card pre {
+  overflow: auto;
+  margin-top: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(3, 9, 18, 0.94);
+  color: #d8fff0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  line-height: 1.7;
+}
+
+.architecture-strip {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.footer-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+@media (max-width: 1080px) {
+  .hero-content,
+  .capability-grid,
+  .architecture-strip {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .page-shell {
+    width: min(calc(100% - 20px), var(--content-width));
+    padding-top: 12px;
+  }
+
+  .topbar,
+  .hero-content,
+  .section,
+  .footer-cta {
+    padding: 20px;
+  }
+
+  .hero-content,
+  .capability-grid,
+  .command-deck,
+  .architecture-strip,
+  .footer-cta {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-cta {
+    display: grid;
+  }
+}
+
+@media (max-width: 560px) {
+  h1 {
+    max-width: none;
+    font-size: clamp(2.4rem, 15vw, 3.5rem);
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .topbar-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero-actions,
+  .footer-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .button {
+    width: 100%;
+  }
+}
+```
+
+- [ ] **Step 4: Verify the stylesheet covers the expected modules**
+
+Run: `rg -n "hero-content|capability-grid|command-deck|architecture-strip|language-toggle|@media" assets/css/homepage.css`
+
+Expected: the file contains layout and responsive rules for every homepage section.
+
+- [ ] **Step 5: Commit the homepage styling**
+
+```bash
+git add assets/css/homepage.css
+git commit -m "feat: style github pages homepage"
+```
+
+### Task 4: Implement language switching and translated copy
+
+**Files:**
+- Create: `assets/js/homepage.js`
+- Modify: `index.html`
+
+- [ ] **Step 1: Write the failing behavior expectation**
+
+Document the interactive behavior:
+
+```text
+On first load, visible copy is English.
+Clicking 中文 switches all translatable text to Chinese without reloading.
+The active language button updates visually.
+```
+
+- [ ] **Step 2: Verify the script file does not already exist**
+
+Run: `test -f assets/js/homepage.js; echo $?`
+
+Expected: `1`
+
+- [ ] **Step 3: Create the translation script**
+
+Create `assets/js/homepage.js` with this content:
+
+```js
+const translations = {
+  en: {
+    nav: { overview: "Overview", github: "GitHub" },
+    hero: {
+      eyebrow: "Protocol. Persistence. Replication.",
+      title: "Build Your Own Redis in Rust",
+      description:
+        "A toy Redis server in Rust that parses RESP, restores from RDB, replicates leader-follower state, supports streams, and queues transactional commands.",
+      primaryCta: "View on GitHub",
+      secondaryCta: "Quick Start",
+    },
+    metrics: {
+      protocol: "Protocol",
+      persistence: "Persistence",
+      replication: "Replication",
+      streams: "Queues",
+    },
+    capabilities: {
+      eyebrow: "Core capabilities",
+      title: "Built around real Redis subsystems",
+      protocol: {
+        title: "Protocol",
+        body: "Parses Redis protocol messages and routes commands through the server runtime.",
+      },
+      persistence: {
+        title: "Persistence",
+        body: "Loads database state from RDB files and restores key metadata.",
+      },
+      replication: {
+        title: "Replication",
+        body: "Bootstraps replica handshake, full sync, and replicated write flow.",
+      },
+      streams: {
+        title: "Streams and transactions",
+        body: "Supports stream operations and queued transactional execution patterns.",
+      },
+    },
+    quickstart: {
+      eyebrow: "Run it",
+      title: "Start fast, then probe with redis-cli",
+      masterLabel: "Master",
+      replicaLabel: "Replica",
+      probeLabel: "Probe",
+    },
+    architecture: {
+      eyebrow: "Implementation map",
+      title: "How the runtime is assembled",
+      protocol: {
+        title: "Protocol ingestion",
+        body: "RESP parsing and request framing for incoming client and replication traffic.",
+      },
+      command: {
+        title: "Command routing",
+        body: "Connection handling, command dispatch, and transaction orchestration.",
+      },
+      storage: {
+        title: "State and restore",
+        body: "In-memory storage backed by RDB parsing and initial database hydration.",
+      },
+      replication: {
+        title: "Replication flow",
+        body: "Replica-side handshake, sync start, and downstream command consumption.",
+      },
+    },
+    footer: {
+      eyebrow: "Source and docs",
+      title: "Inspect the code, then dive deeper",
+      github: "Open GitHub Repository",
+      readmeEn: "Read README",
+      readmeZh: "Read Chinese README",
+    },
+  },
+  zh: {
+    nav: { overview: "概览", github: "GitHub" },
+    hero: {
+      eyebrow: "协议。持久化。复制。",
+      title: "用 Rust 构建自己的 Redis",
+      description:
+        "一个用 Rust 编写的 toy Redis server，支持 RESP 解析、RDB 恢复、主从复制、Stream，以及事务命令排队执行。",
+      primaryCta: "查看 GitHub 仓库",
+      secondaryCta: "快速开始",
+    },
+    metrics: {
+      protocol: "协议",
+      persistence: "持久化",
+      replication: "复制",
+      streams: "队列",
+    },
+    capabilities: {
+      eyebrow: "核心能力",
+      title: "围绕真实 Redis 子系统构建",
+      protocol: {
+        title: "协议处理",
+        body: "解析 Redis 协议消息，并把命令路由到服务端运行时。",
+      },
+      persistence: {
+        title: "持久化",
+        body: "从 RDB 文件加载数据库状态，并恢复键的元数据。",
+      },
+      replication: {
+        title: "主从复制",
+        body: "完成 replica 握手、全量同步和写命令复制流程。",
+      },
+      streams: {
+        title: "流与事务",
+        body: "支持 Stream 相关操作，以及事务命令排队和执行模式。",
+      },
+    },
+    quickstart: {
+      eyebrow: "开始运行",
+      title: "先跑起来，再用 redis-cli 探测",
+      masterLabel: "主节点",
+      replicaLabel: "从节点",
+      probeLabel: "探测命令",
+    },
+    architecture: {
+      eyebrow: "实现映射",
+      title: "运行时如何拼装起来",
+      protocol: {
+        title: "协议入口",
+        body: "负责 RESP 解析，以及客户端与复制流量的请求分帧。",
+      },
+      command: {
+        title: "命令路由",
+        body: "负责连接处理、命令分发，以及事务编排。",
+      },
+      storage: {
+        title: "状态与恢复",
+        body: "以内存存储为核心，并由 RDB 解析完成初始数据装载。",
+      },
+      replication: {
+        title: "复制链路",
+        body: "负责 replica 侧握手、同步启动和下游命令消费。",
+      },
+    },
+    footer: {
+      eyebrow: "源码与文档",
+      title: "先看代码，再继续深入",
+      github: "打开 GitHub 仓库",
+      readmeEn: "查看英文 README",
+      readmeZh: "查看中文 README",
+    },
+  },
+};
+
+const LANG_STORAGE_KEY = "redis-rs-homepage-language";
+
+function getValue(source, path) {
+  return path.split(".").reduce((acc, key) => acc && acc[key], source);
+}
+
+function applyLanguage(lang) {
+  const dictionary = translations[lang] || translations.en;
+  document.documentElement.lang = lang === "zh" ? "zh-CN" : "en";
+
+  document.querySelectorAll("[data-i18n]").forEach((node) => {
+    const value = getValue(dictionary, node.dataset.i18n);
+    if (typeof value === "string") {
+      node.textContent = value;
+    }
+  });
+
+  document.querySelectorAll(".lang-btn").forEach((button) => {
+    button.classList.toggle("is-active", button.dataset.lang === lang);
+    button.setAttribute("aria-pressed", String(button.dataset.lang === lang));
+  });
+
+  window.localStorage.setItem(LANG_STORAGE_KEY, lang);
+}
+
+function preferredLanguage() {
+  const saved = window.localStorage.getItem(LANG_STORAGE_KEY);
+  return saved === "zh" ? "zh" : "en";
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  applyLanguage(preferredLanguage());
+
+  document.querySelectorAll(".lang-btn").forEach((button) => {
+    button.addEventListener("click", () => {
+      applyLanguage(button.dataset.lang === "zh" ? "zh" : "en");
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Ensure all user-facing strings use translation hooks**
+
+Update any untranslated visible labels in `index.html` so they either:
+- use `data-i18n`, or
+- are intentionally non-language-specific code/file labels such as `protocol.rs` or `RESP`
+
+For example, this button group should remain:
+
+```html
+<div class="language-toggle" role="group" aria-label="Language switcher">
+  <button class="lang-btn is-active" type="button" data-lang="en">EN</button>
+  <button class="lang-btn" type="button" data-lang="zh">中文</button>
+</div>
+```
+
+while user-facing copy such as headings and CTA text should be translated with `data-i18n`.
+
+- [ ] **Step 5: Verify translation coverage**
+
+Run: `rg -n "data-i18n" index.html && node -e "const fs=require('fs'); const html=fs.readFileSync('index.html','utf8'); const keys=[...html.matchAll(/data-i18n=\"([^\"]+)\"/g)].map(m=>m[1]); console.log(keys.length)" && sed -n '1,260p' assets/js/homepage.js | sed -n '1,220p'`
+
+Expected:
+- `index.html` contains translation hooks across the page
+- script defines both `en` and `zh`
+- English remains the default fallback
+
+- [ ] **Step 6: Commit the bilingual interaction**
+
+```bash
+git add index.html assets/js/homepage.js
+git commit -m "feat: add bilingual homepage interactions"
+```
+
+### Task 5: Verify the site in the real Pages pipeline
+
+**Files:**
+- Verify: `index.html`
+- Verify: `assets/css/homepage.css`
+- Verify: `assets/js/homepage.js`
+- Verify: `_config.yml`
+- Verify: `index.md`
+
+- [ ] **Step 1: Build the site locally**
+
+Run: `bundle exec jekyll build`
+
+Expected: build exits successfully and writes the generated site to `_site/`.
+
+- [ ] **Step 2: Verify the generated root page includes the homepage**
+
+Run: `rg -n "Build Your Own Redis in Rust|language-toggle|Built around real Redis subsystems|Open GitHub Repository" _site/index.html`
+
+Expected: generated root page contains the homepage hero, language toggle, capability section, and footer CTA.
+
+- [ ] **Step 3: Verify the overview page still exists**
+
+Run: `test -f _site/overview/index.html && echo ok`
+
+Expected: `ok`
+
+- [ ] **Step 4: Serve the built site and smoke-check it**
+
+Run:
+
+```bash
+ruby -run -e httpd _site -p 4000
+```
+
+Then in a second shell:
+
+```bash
+curl -s http://127.0.0.1:4000/ | rg "Build Your Own Redis in Rust|redis-rs"
+curl -s http://127.0.0.1:4000/overview/ | rg "概览|旨在从 0 到 1 实现一个基础的 redis-server 版本"
+```
+
+Expected:
+- root responds with homepage content
+- `/overview/` responds with the previous markdown overview
+
+- [ ] **Step 5: Commit after successful verification**
+
+```bash
+git add index.html index.md _config.yml assets/css/homepage.css assets/js/homepage.js .gitignore
+git commit -m "feat: launch github pages project homepage"
+```

--- a/docs/superpowers/specs/2026-06-17-github-pages-homepage-design.md
+++ b/docs/superpowers/specs/2026-06-17-github-pages-homepage-design.md
@@ -1,0 +1,344 @@
+# GitHub Pages Homepage Design for `redis-rs`
+
+## Goal
+
+Build a distinctive project homepage for `redis-rs` using GitHub Pages.
+
+The homepage should:
+
+- present the project as a polished engineering artifact rather than a plain README mirror
+- default to English
+- support in-page English/Chinese switching
+- link clearly to the GitHub repository
+- remain simple to deploy and maintain inside this Rust repository
+
+## Scope
+
+This work covers a single static homepage deployed from the repository itself.
+
+In scope:
+
+- one-page project homepage under `docs/`
+- bilingual copy for English and Chinese
+- English as the initial language
+- responsive layout for desktop and narrow screens
+- GitHub repository CTA and README entry points
+- lightweight interaction and motion
+
+Out of scope:
+
+- blogs, changelog pages, or multi-page docs IA
+- external CMS or site generator adoption
+- build tooling such as Vite, React, or bundlers
+- server-side rendering or dynamic backend integration
+
+## Recommended Direction
+
+Use the approved `A. Signal Wall` direction.
+
+This direction gives the repo a stronger first screen than a documentation-first layout while still preserving the practical information a visitor needs:
+
+- what the project is
+- what it supports
+- how to run it
+- how the implementation is structured
+- where the source lives
+
+It is the best fit for a GitHub-hosted project page because it balances visual identity with engineering clarity.
+
+## Audience
+
+Primary audiences:
+
+- developers browsing the repository from GitHub
+- Rust learners interested in implementing Redis concepts
+- people evaluating the project quickly from a shared link
+
+What they need from the homepage:
+
+- a fast explanation of what `redis-rs` does
+- confidence that the project has real implemented subsystems
+- a short path to source code and setup commands
+
+## Content Strategy
+
+The page should be grounded in the current repository, not generic Redis marketing.
+
+Core content signals should come from the current README and source structure:
+
+- RESP protocol handling
+- basic Redis commands
+- RDB parsing and initialization
+- leader-follower replication
+- streams
+- transaction queueing and execution
+
+The architecture strip should map visible source modules into readable concepts:
+
+- `protocol.rs`
+- `server.rs`
+- `cmd.rs`
+- `storage.rs`
+- `rdb.rs`
+- `replication_client.rs`
+
+## Information Architecture
+
+The homepage should be a single scrolling page in this order:
+
+1. Hero
+2. Capability modules
+3. Quick start
+4. Architecture strip
+5. Repository and docs CTA
+
+### 1. Hero
+
+Purpose:
+
+- establish the project's identity immediately
+- communicate the core value in one screen
+- expose the language switch and main calls to action
+
+Content:
+
+- project name: `redis-rs`
+- English headline: `Build Your Own Redis in Rust`
+- Chinese equivalent for toggle mode
+- short supporting sentence summarizing protocol, persistence, replication, streams, and transactions
+- primary CTA: GitHub repository
+- secondary CTA: jump to Quick Start
+- language toggle: `EN` and `中文`
+
+### 2. Capability Modules
+
+Purpose:
+
+- communicate real technical depth quickly
+
+Presentation:
+
+- four visually strong modules rather than generic feature cards
+
+Modules:
+
+- Protocol
+- Persistence
+- Replication
+- Streams and Transactions
+
+Each module should have:
+
+- short title
+- concise explanatory copy
+- one supporting technical cue, such as a protocol or command label
+
+### 3. Quick Start
+
+Purpose:
+
+- make the project feel runnable, not just descriptive
+
+Content:
+
+- `cargo run` startup examples for master and replica roles
+- selected `redis-cli` commands drawn from the README
+- short section labels that also translate during language switching
+
+This section should look like an integrated command deck, not a plain markdown code dump.
+
+### 4. Architecture Strip
+
+Purpose:
+
+- show that the implementation has understandable internal structure
+
+Presentation:
+
+- a horizontal or stacked system view depending on viewport width
+- each segment maps one or more source files to a subsystem responsibility
+
+Example conceptual mapping:
+
+- protocol ingestion
+- command routing
+- in-memory storage
+- RDB loading
+- replication flow
+
+This is not a formal diagram tool output. It is a stylized structural band embedded in the page.
+
+### 5. Repository and Docs CTA
+
+Purpose:
+
+- give a clean exit path into the real repo and supporting docs
+
+Content:
+
+- GitHub repo link
+- README link
+- Chinese README link
+
+This section should be visually simpler than the hero and close the page cleanly.
+
+## Visual Design
+
+Approved aesthetic: dark cyber technical.
+
+The page should feel like a polished systems project page, not a startup landing page.
+
+### Visual principles
+
+- dark blue-black foundation
+- cyan and mint accents
+- restrained glow, grid, scanline, and signal motifs
+- sharp, structured layout with clear visual hierarchy
+- command-line and systems cues without becoming cluttered
+
+### Typography
+
+- distinctive display face for hero headline
+- high-legibility sans-serif or equivalent for body copy
+- monospace for code and protocol cues
+
+### Motion
+
+Use only lightweight effects:
+
+- hero entrance
+- hover states
+- subtle flowing accents in system bands
+- smooth language switch transitions
+
+Avoid:
+
+- heavy 3D scenes
+- scroll-jacking
+- large scripted animation systems
+
+## Interaction Design
+
+The only meaningful stateful interaction is language switching.
+
+Requirements:
+
+- default language is English
+- switching to Chinese updates the whole page content in place
+- switching does not reload the page
+- labels, buttons, section copy, and navigation text all update together
+- active language state is visually clear
+
+Optional enhancement:
+
+- remember the user's last language via local storage if implemented simply
+
+If persistence adds unnecessary complexity, it may be skipped.
+
+## Technical Design
+
+Implement as a static GitHub Pages-friendly site by reusing the repository's existing Jekyll Pages pipeline.
+
+Planned files:
+
+- `index.html`
+- `assets/css/homepage.css`
+- `assets/js/homepage.js`
+
+Optional supporting files:
+
+- `assets/images/*` for light textures or decorative bitmap assets if needed
+
+Rationale:
+
+- the repository already ships a root-level Jekyll Pages workflow, so reusing it is lower risk than replacing it
+- no extra frontend build pipeline required
+- minimal maintenance burden
+- easy for future contributors to edit
+
+Implementation note:
+
+- preserve the existing markdown overview by moving it off the root route
+- serve the new homepage from the root Pages entrypoint
+
+## Content Model
+
+Use a small structured translation object in `docs/app.js` keyed by language.
+
+The script should:
+
+- hold English and Chinese copy
+- update text targets through `data-i18n` attributes
+- update toggle button active state
+- optionally persist the selected language
+
+This avoids duplicating page markup for each language and keeps all copy synchronized.
+
+## Responsive Behavior
+
+Requirements:
+
+- hero remains readable and visually strong on mobile
+- command blocks do not overflow horizontally beyond normal code scrolling behavior
+- architecture strip collapses into stacked sections on narrow screens
+- CTA group and language switch remain accessible on small screens
+
+The design should prioritize a stable layout over aggressive scaling tricks.
+
+## Accessibility and UX Constraints
+
+- maintain sufficient text contrast in all sections
+- use semantic headings and buttons/links
+- ensure language toggle is keyboard reachable
+- preserve readability even with decorative effects enabled
+- avoid motion that obscures content or distracts from scanning
+
+## Verification Plan
+
+Before claiming completion:
+
+1. Serve the static files locally and load the page in a browser.
+2. Verify English is the default language on first load.
+3. Verify switching to Chinese updates visible copy correctly.
+4. Verify GitHub and README links resolve correctly.
+5. Verify desktop and narrow-screen layouts remain intact.
+
+## Implementation Notes
+
+- Keep edits scoped to the new `docs/` page assets and any minimal supporting repo configuration.
+- Do not replace or heavily rewrite the existing README files.
+- Do not introduce a framework or static site generator for this task.
+
+## Risks and Mitigations
+
+### Risk: homepage becomes a README clone
+
+Mitigation:
+
+- keep sections concise and visually staged
+- use README as source material, not as page structure
+
+### Risk: bilingual support becomes brittle
+
+Mitigation:
+
+- centralize copy in one translation object
+- bind text updates through explicit selectors or `data-i18n`
+
+### Risk: visual effects hurt readability
+
+Mitigation:
+
+- keep background effects low contrast
+- keep body text and command zones visually calm
+
+## Acceptance Criteria
+
+The work is complete when:
+
+- a GitHub Pages-compatible homepage exists under `docs/`
+- the page defaults to English
+- the page supports in-place English/Chinese switching
+- the page includes a visible GitHub repository link
+- the page reflects the real project capabilities and module structure
+- the page works on desktop and narrow screens without layout breakage

--- a/docs/zh/command-execution.md
+++ b/docs/zh/command-execution.md
@@ -1,0 +1,137 @@
+---
+title: 命令执行
+layout: default
+nav_exclude: true
+permalink: /zh/docs/command-execution/
+---
+
+# 命令执行
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [RESP 协议]({{ '/zh/docs/resp-protocol/' | relative_url }}) | [Streams 与事务]({{ '/zh/docs/streams-and-transactions/' | relative_url }})
+
+这一章聚焦 `cmd.rs`，也就是整个仓库里命令语义最密集的地方。
+
+## 文件边界
+
+- `src/cmd.rs`
+- `src/server.rs`
+- `src/protocol.rs`
+
+## 为什么 `cmd.rs` 是语义中心
+
+`src/cmd.rs` 是仓库里体量最大的行为模块之一，这里同时承担了：
+
+- 把协议数组变成命令枚举
+- 把命令分发到具体 helper
+- 把写命令和复制规则接起来
+- 把 stream 和事务挂进同一条执行链
+
+如果说 `server.rs` 是运行时外壳，那 `cmd.rs` 就是语义核心。
+
+## 命令枚举
+
+`Cmd` 总结了当前支持的命令面，包括：
+
+- 字符串命令：`GET`、`SET`、`DEL`、`INCR`
+- 信息查看命令：`CONFIG GET`、`INFO`、`TYPE`
+- 复制相关命令：`REPLCONF`、`PSYNC`
+- Stream 命令：`XADD`、`XRANGE`、`XREAD`
+- 事务命令：`MULTI`、`EXEC`、`DISCARD`
+
+无法识别的输入会落到 `Unknow`。
+
+## 解析路径
+
+`Cmd::from(...)` 从一个已解析的 `Protocol` 开始，要求顶层必须是数组。
+
+控制流是：
+
+1. 先调 `Protocol::from(...)`
+2. 确认顶层是 `Protocol::Array`
+3. 把每个子元素 `decode()` 成 token
+4. 按第一个 token 匹配命令类型
+5. 对每条命令检查参数个数和形状
+6. 返回 `(Cmd, Protocol)`
+
+这里同时返回原始 `Protocol` 很重要，因为后面复制广播还需要原始命令载荷。
+
+## 分发路径
+
+`Cmd::run(...)` 是中央调度器。
+
+它接收：
+
+- `&mut Server`
+- 原始 `Protocol`
+- `is_rep_con`
+- `queued_cmd`
+
+再把命令路由到各个 helper，例如：
+
+- `get_cmd(...)`
+- `set_cmd(...)`
+- `keys_cmd(...)`
+- `info_cmd(...)`
+- `xadd_cmd(...)`
+- `exec_cmd(...)`
+
+这样解析、调度和具体语义就被分层了。
+
+## 统一的写命令 helper
+
+很多写命令最终都会走 `resp_and_replicate(...)`。
+
+它负责统一决定：
+
+- 本地应该返回什么响应
+- 是否要向 replicas 广播原始命令
+- slave 是否要拒绝普通客户端写入
+
+这避免了每个写命令都重复实现一遍复制规则。
+
+## 信息查看类命令
+
+`config_get_cmd(...)` 和 `info_cmd(...)` 基本不碰存储层，它们只是把 `server.option` 里的配置和复制状态序列化成 `Protocol` 响应。
+
+这给项目提供了一条轻量的自描述接口。
+
+## `KEYS` 和 `TYPE`
+
+`keys_cmd(...)` 直接从字符串存储里返回当前键集合。
+
+`type_cmd(...)` 则会先查普通存储，再查 stream 容器，然后返回：
+
+- `string`
+- `stream`
+- `none`
+
+它是“字符串容器”和“stream 容器”两条数据线在客户端层面汇合的一个例子。
+
+## `INCR`
+
+`incr_cmd(...)` 的流程是：
+
+1. 读出当前值
+2. 如果 key 不存在，默认当作 `1`
+3. 尝试把字符串解析成 `u64`
+4. 自增并写回为字符串
+5. 如果解析失败，返回显式错误
+
+这也说明当前存储层始终是“字符串优先”，数值语义是在命令层附加出来的。
+
+## Offset 统计
+
+命令成功执行后，`Cmd::run(...)` 会用原始协议编码后的长度递增 `server.offset`。
+
+所以 offset 统计附着在“命令完成”这个节点上，而不是附着在 socket read 位置上。
+
+这个模型很粗，但在整个仓库里是一致的。
+
+## 当前实现限制
+
+- 命令解析默认输入已经是完整数组
+- 很多分支仍然假设参数形状良好
+- 不支持的命令会收敛到统一 unknown 分支
+- 有些 helper 内部还保留了 unwrap 风格
+
+尽管如此，`cmd.rs` 已经足够清楚地展示一个 Redis-like 服务器的命令驱动结构。

--- a/docs/zh/commands-streams-and-transactions.md
+++ b/docs/zh/commands-streams-and-transactions.md
@@ -1,0 +1,149 @@
+---
+title: 命令、流与事务
+layout: default
+nav_exclude: true
+permalink: /zh/docs/commands-streams-and-transactions/
+---
+
+# 命令、流与事务
+
+[返回首页]({{ '/' | relative_url }}) | [总览]({{ '/overview/' | relative_url }}) | [运行时与协议]({{ '/zh/docs/runtime-and-protocol/' | relative_url }}) | [持久化与复制]({{ '/zh/docs/persistence-and-replication/' | relative_url }})
+
+这一章覆盖命令解析、执行分发，以及超出基本 key-value 读写之外的 Stream 与事务能力。
+
+## 文件边界
+
+- `src/cmd.rs`
+- `src/storage.rs`
+- `src/server.rs`
+
+## 命令解析
+
+`Cmd::from(...)` 会把 RESP 数组转换成一个强类型命令枚举。
+
+当前支持的命令包括：
+
+- `PING`
+- `ECHO`
+- `GET`
+- `SET`
+- `SET PX`
+- `SET EX`
+- `DEL`
+- `KEYS *`
+- `CONFIG GET`
+- `INFO`
+- `TYPE`
+- `INCR`
+- `REPLCONF`
+- `PSYNC`
+- `XADD`
+- `XRANGE`
+- `XREAD`
+- `MULTI`
+- `EXEC`
+- `DISCARD`
+
+这里的 `Cmd` 枚举就是整个服务端的命令边界。
+
+## 执行入口
+
+`Cmd::run(...)` 是调度中心。它接收：
+
+- 可变的 `Server`
+- 原始 `Protocol`
+- 是否为复制连接
+- 当前事务排队状态
+
+然后再把具体命令路由到更小的 helper，例如：
+
+- `get_cmd(...)`
+- `set_cmd(...)`
+- `xadd_cmd(...)`
+- `xread_cmd(...)`
+- `exec_cmd(...)`
+
+这样解析和执行是分开的：`Cmd::from(...)` 负责“这是什么命令”，`run(...)` 负责“它要做什么”。
+
+## 基础存储命令
+
+对字符串键来说，`cmd.rs` 最终还是会落到 `Storage`：
+
+- `GET` -> `storage.get(...)`
+- `SET` / 定时 `SET` -> `set(...)` 或 `setx(...)`
+- `DEL` -> 删除键
+- `INCR` -> 取出字符串数值、自增后写回
+
+这层保持了“所有值先当字符串处理”的思路，也让 RDB 恢复和 RESP 输出更直白。
+
+## Stream 数据模型
+
+`Server` 对 stream 单独维护了一套结构：
+
+```text
+HashMap<String, BTreeMap<String, Vec<(String, String)>>>
+```
+
+可以理解成：
+
+- 顶层 `HashMap` 的 key 是 stream 名
+- 内层 `BTreeMap` 的 key 是 entry id
+- value 是 field/value 对列表
+
+因为内部用的是 `BTreeMap`，范围查询天然更顺手。
+
+## Stream 命令
+
+`cmd.rs` 当前支持的 stream 命令有：
+
+- `XADD`
+- `XRANGE`
+- `XREAD`
+
+它们负责的关键行为包括：
+
+- 校验 stream id
+- 支持 `*` 自动生成 id
+- 单 stream 范围查询
+- 多 stream 读取
+- `XREAD` 的可选阻塞模式
+
+阻塞读取会借助 `server.stream_reader_blocker` 来协调唤醒逻辑。
+
+## 事务实现
+
+事务的核心状态是：
+
+```text
+queued_cmd: Option<Vec<(Cmd, Protocol)>>
+```
+
+行为如下：
+
+- `MULTI` 创建空队列
+- 后续普通命令入队，并返回 `QUEUED`
+- `EXEC` 依次执行队列中的命令
+- `DISCARD` 清空队列
+
+这个实现的一个优点是没有再造第二套执行器，而是复用：
+
+- 已解析好的 `Cmd`
+- 原始 `Protocol`
+- 现有的 `run(...)` 分发逻辑
+
+因此，事务执行本质上是“关闭排队模式后，再重放一次相同命令”。
+
+## 与复制偏移量的关系
+
+命令执行成功后，`Cmd::run(...)` 会用协议编码后的长度去递增 `server.offset`。
+
+这个 offset 不是完整 Redis 的复制状态机，但足够表达“有多少写流量从当前节点流过”。
+
+## 当前实现限制
+
+- 每条命令都假定 RESP 数组形状基本正确
+- 不支持的命令会落到 `Unknow`
+- 事务队列是连接本地状态
+- Stream 和事务行为强调学习可读性，而不是完全对齐 Redis 的边缘语义
+
+这和整个项目的目标一致：让命令执行、Stream 数据结构、事务排队这几块能被直接读懂。

--- a/docs/zh/overview.md
+++ b/docs/zh/overview.md
@@ -1,0 +1,64 @@
+---
+title: 文档总览
+layout: default
+nav_exclude: true
+permalink: /zh/docs/overview/
+---
+
+# 文档总览
+
+[返回首页]({{ '/' | relative_url }}) | [项目概览]({{ '/overview/' | relative_url }}) | [运行时与服务端]({{ '/zh/docs/server-runtime/' | relative_url }}) | [RESP 协议]({{ '/zh/docs/resp-protocol/' | relative_url }})
+
+这里的文档区不再把实现细节压成少数几篇概览，而是按源码职责拆开，便于顺着代码边界逐步阅读。
+
+## 推荐阅读路径
+
+如果你想按控制流理解整个实现，可以按这个顺序：
+
+1. 运行时入口与共享服务端状态
+2. RESP 协议解析和编码
+3. 字符串键值存储模型
+4. RDB 文件解析
+5. 主从复制链路
+6. 命令分发
+7. Stream 与事务
+
+## 章节地图
+
+- [运行时与服务端]({{ '/zh/docs/server-runtime/' | relative_url }})
+  - `src/main.rs`
+  - `src/server.rs`
+  - `src/options.rs`
+- [RESP 协议]({{ '/zh/docs/resp-protocol/' | relative_url }})
+  - `src/protocol.rs`
+- [存储模型]({{ '/zh/docs/storage-model/' | relative_url }})
+  - `src/storage.rs`
+  - `src/server.rs`
+- [RDB 解析器]({{ '/zh/docs/rdb-parser/' | relative_url }})
+  - `src/rdb.rs`
+- [复制链路]({{ '/zh/docs/replication-flow/' | relative_url }})
+  - `src/main.rs`
+  - `src/replication_client.rs`
+  - `src/server.rs`
+  - `src/cmd.rs`
+- [命令执行]({{ '/zh/docs/command-execution/' | relative_url }})
+  - `src/cmd.rs`
+  - `src/server.rs`
+  - `src/protocol.rs`
+- [Streams 与事务]({{ '/zh/docs/streams-and-transactions/' | relative_url }})
+  - `src/cmd.rs`
+  - `src/server.rs`
+
+## 为什么改成这个结构
+
+这个仓库虽然不大，但实现边界是清楚的：
+
+- 入口和运行时
+- 协议层
+- 存储层
+- RDB 持久化
+- 复制链路
+- 命令语义
+- Stream / 事务扩展
+
+如果只保留 3 个大章节，很多控制流和数据流会被压平，看不出模块职责。

--- a/docs/zh/persistence-and-replication.md
+++ b/docs/zh/persistence-and-replication.md
@@ -1,0 +1,113 @@
+---
+title: 持久化与复制
+layout: default
+nav_exclude: true
+permalink: /zh/docs/persistence-and-replication/
+---
+
+# 持久化与复制
+
+[返回首页]({{ '/' | relative_url }}) | [总览]({{ '/overview/' | relative_url }}) | [运行时与协议]({{ '/zh/docs/runtime-and-protocol/' | relative_url }}) | [命令、流与事务]({{ '/zh/docs/commands-streams-and-transactions/' | relative_url }})
+
+这一章覆盖项目如何从 RDB 文件恢复状态，以及 master/slave 之间的同步链路是怎么接起来的。
+
+## 文件边界
+
+- `src/rdb.rs`
+- `src/replication_client.rs`
+- `src/server.rs`
+
+## RDB 加载入口
+
+master 启动时会在 `Server::init(...)` 中打开配置里的 DB 文件。只有文件非空时，才会进入 RDB 解析流程。
+
+调用链如下：
+
+1. `Server::init(...)`
+2. `rdb::parse_rdb_file(...)`
+3. `rdb::parse_rdb(...)`
+
+解析出来的数据会直接写入 `server.storage`。
+
+## 当前支持的 RDB 内容
+
+`src/rdb.rs` 实现的是一个聚焦版 RDB 解析器，当前覆盖：
+
+- magic header 校验
+- 版本读取
+- metadata 辅助字段
+- 数据库选择标记
+- table size 信息
+- 不带过期时间的字符串键值
+- 带过期时间的字符串键值
+- EOF 与 CRC 读取
+
+其中过期时间支持两种编码：
+
+- `0xFC`：毫秒时间戳
+- `0xFD`：秒时间戳
+
+如果 entry 自带过期时间，解析器会走 `Storage::setx(...)`。
+
+## 字符串解码模型
+
+当前支持的 string encoding 有：
+
+- 原始字符串
+- 8 位整数
+- 16 位整数
+- 32 位整数
+
+LZF 压缩字符串明确返回“不支持”，不会被悄悄跳过。
+
+## 持久化与存储层的配合
+
+`src/storage.rs` 很小，只做三件关键事：
+
+- `set(...)` 写普通值
+- `setx(...)` 写带绝对过期时间的值
+- `get(...)` 在读取时顺便清理过期键
+
+这让 RDB 层只需要判断“有没有过期信息”，然后调用正确的存储接口即可。
+
+## 从节点握手流程
+
+`src/replication_client.rs` 里的 `FollowerReplicationClient` 按顺序完成：
+
+1. `PING`
+2. `REPLCONF listening-port <port>`
+3. `REPLCONF capa psync2`
+4. `PSYNC ? -1`
+
+每一步都会通过 `check_resp(...)` 校验返回值是否符合预期。
+
+## 全量同步
+
+`PSYNC` 之后，从节点会继续读取：
+
+1. `FULLRESYNC` 响应行
+2. `$<len>` 形式的 RDB 长度头
+3. 真正的 RDB 二进制快照
+
+拿到快照后，不会再走另一套专门逻辑，而是直接复用 `rdb::parse_rdb(...)`。
+
+这点很重要：本地文件恢复和主从快照恢复，共用的是同一条 RDB 解码路径。
+
+## Master 侧复制行为
+
+当 master 在 `Server::handle(...)` 中收到 `PSYNC`：
+
+1. 通过 `MasterReplicationClient::send_rdb_file(...)` 发出 RDB 数据
+2. 用 `add_stream(...)` 把 replica 的 socket 记下来
+3. 不再把这个连接当成普通请求-响应客户端
+
+后续复制写命令的 fan-out，则由 `MasterReplicationClient::send_command(...)` 负责。
+
+## 当前实现限制
+
+- master 发送的是常量的空 RDB 种子内容
+- CRC 被读取但不校验
+- metadata 会被解析但暂时忽略
+- 复制状态跟踪远小于生产级 Redis
+
+这些取舍让重点落在“如何恢复状态、如何建立角色关系、如何开始回放写流量”上。

--- a/docs/zh/rdb-parser.md
+++ b/docs/zh/rdb-parser.md
@@ -1,0 +1,152 @@
+---
+title: RDB 解析器
+layout: default
+nav_exclude: true
+permalink: /zh/docs/rdb-parser/
+---
+
+# RDB 解析器
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [存储模型]({{ '/zh/docs/storage-model/' | relative_url }}) | [复制链路]({{ '/zh/docs/replication-flow/' | relative_url }})
+
+这一章把 RDB 快照解析单独抽出来讲，不和复制链路混在一起。
+
+## 文件边界
+
+- `src/rdb.rs`
+
+## 这个模块的职责
+
+`src/rdb.rs` 只做一件事：把 RDB 字节流解析成对 `server.storage` 的写入。
+
+它被复用在两个场景：
+
+- master 本地启动时从 DB 文件恢复
+- slave 从 master 下载快照后恢复
+
+这点很重要，因为仓库里只有一条 RDB 解码路径。
+
+## 入口函数
+
+模块对外有两个入口：
+
+- `parse_rdb_file(...)`
+- `parse_rdb(...)`
+
+`parse_rdb_file(...)` 只是包装了一层 `BufReader`。
+
+真正的流式解析逻辑都在 `parse_rdb(...)` 里，它接受任何 `AsyncRead + Unpin`，所以网络流和文件流都能复用。
+
+## 总体控制流
+
+`parse_rdb(...)` 的流程是：
+
+1. 锁住 `server.storage`
+2. `parse_magic(...)`
+3. `parse_version(...)`
+4. 进入 opcode 循环
+5. 遇到 `EOF` 结束
+
+循环里当前识别这些 opcode：
+
+- `META`
+- `DB_SELECT`
+- `TABLE_SIZE_INFO`
+- `EOF`
+
+其他 opcode 都直接报错。
+
+## Header 校验
+
+`parse_magic(...)` 会读取 5 个字节并校验是否为 `REDIS`。
+
+`parse_version(...)` 再读取 4 个字节版本号。
+
+当前实现只验证结构，不做更细的版本分支逻辑。
+
+## Metadata 段
+
+当遇到 `META` 时，代码会调用两次 `parse_aux(...)`，然后丢弃结果。
+
+也就是说 metadata 是“语法上解析了，但语义上忽略了”。
+
+这个取舍很合理：
+
+- 结构上贴近真实 RDB
+- 又不需要额外引入一套 metadata 模型
+
+## DB 选择和表大小信息
+
+`DB_SELECT` 会被读出来，但因为这个项目实际上只处理单个逻辑 DB，所以结果被忽略。
+
+`TABLE_SIZE_INFO` 则更关键，它提供：
+
+- 不带过期时间的 entry 数量
+- 带过期时间的 entry 数量
+
+随后解析器就按这两个计数分别读取对应数量的 entry。
+
+## Entry 解析
+
+目前有两条 entry 解析路径：
+
+- `parse_no_expire_entry(...)`
+- `parse_expire_entry(...)`
+
+两者都默认 value type 为字符串类型 `0`。
+
+所以这个实现聚焦的是字符串键，而不是完整 Redis 类型矩阵。
+
+## 过期时间解码
+
+`parse_expire_entry(...)` 支持两种编码：
+
+- `0xFC`：8 字节 little-endian 毫秒时间戳
+- `0xFD`：4 字节 little-endian 秒级时间戳
+
+秒级时间戳会先转成毫秒，再写入存储层。
+
+这样整个仓库内部就统一成毫秒时间单位。
+
+## 长度与字符串解码
+
+`parse_len(...)` 会解释 RDB 的长度前缀，并返回：
+
+- 解码后的长度
+- `StringEncoding`
+
+目前支持的字符串编码有：
+
+- `Raw`
+- `I8`
+- `I16`
+- `I32`
+- `LZF`
+
+`parse_string(...)` 可以处理前四种，`LZF` 则明确返回“不支持”。
+
+## 如何写入存储层
+
+entry 一旦解析出来，就会立刻写入 `storage`：
+
+- 不带过期 -> `storage.set(...)`
+- 带过期 -> `storage.setx(...)`
+
+这里不会先构造一棵中间对象树，而是边读边落到运行时状态里。
+
+## CRC 处理
+
+读到 `EOF` 后，代码会再读 8 字节 CRC，但不会验证它。
+
+也就是说文件尾结构被消费了，但校验逻辑还没实现。
+
+## 当前实现限制
+
+- 只支持 RDB 的一部分结构
+- metadata 被忽略
+- DB index 被忽略
+- 只处理字符串类型 entry
+- LZF 不支持
+- CRC 不校验
+
+尽管如此，这个解析器已经足够展示 Redis 持久化格式的关键骨架，并且能支撑本地恢复和复制快照恢复。

--- a/docs/zh/replication-flow.md
+++ b/docs/zh/replication-flow.md
@@ -1,0 +1,137 @@
+---
+title: 复制链路
+layout: default
+nav_exclude: true
+permalink: /zh/docs/replication-flow/
+---
+
+# 复制链路
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [运行时与服务端]({{ '/zh/docs/server-runtime/' | relative_url }}) | [RDB 解析器]({{ '/zh/docs/rdb-parser/' | relative_url }})
+
+这一章专门讲 master/slave 之间如何建立关系、传输快照，以及后续如何广播写命令。
+
+## 文件边界
+
+- `src/main.rs`
+- `src/replication_client.rs`
+- `src/server.rs`
+- `src/cmd.rs`
+
+## Slave 启动链路
+
+slave 的复制启动过程是显式写在 `main.rs` 里的。
+
+顺序如下：
+
+1. 构造 `Server`
+2. 创建 `FollowerReplicationClient`
+3. `ping_master()`
+4. `report_port(...)`
+5. `report_sync_protocol()`
+6. `start_psync(...)`
+7. 再为复制 socket 启动一个 `Server::handle(...)`
+
+所以复制控制流并没有被藏起来，入口处就能看见。
+
+## Follower 侧握手
+
+`FollowerReplicationClient` 会在一条 `TcpStream` 上按顺序发送：
+
+1. `PING`
+2. `REPLCONF listening-port <port>`
+3. `REPLCONF capa psync2`
+4. `PSYNC ? -1`
+
+每一步都会通过 `check_resp(...)` 校验返回值是否匹配预期。
+
+## `PSYNC` 之后会读什么
+
+`start_psync(...)` 发完命令后，立即进入 `recv_rdb_file(...)`。
+
+这里期待的输入是：
+
+1. 一行类似 `FULLRESYNC <id> <offset>` 的信息
+2. 一个 `$<len>` 形式的快照长度头
+3. 真正的 RDB 二进制快照内容
+
+快照内容不会走另一套解析逻辑，而是直接复用 `rdb::parse_rdb(...)`。
+
+## Master 侧如何处理 `PSYNC`
+
+master 对 `PSYNC` 的处理跨了两个层次：
+
+- `Cmd::from(...)` 把它识别成 `Cmd::Psync`
+- `Server::handle(...)` 在命令执行后对这个 socket 做特殊处理
+
+`Server::handle(...)` 中的分支是复制模式切换的关键：
+
+1. 调 `send_rdb_file(...)`
+2. 调 `add_stream(...)`
+3. 跳出普通请求循环
+
+从这一刻起，这个 socket 就是一个已注册的 replica 下游。
+
+## 为什么 Master 行为不全写在 `cmd.rs`
+
+`PSYNC` 既是：
+
+- 一条逻辑命令
+- 一次连接模式切换
+
+后者必须在 `server.rs` 里做，因为服务端需要接管并保存这个 replica socket 以便后续 fan-out。
+
+所以当前实现故意把控制流拆成两层：
+
+- 命令语义 -> `psync_cmd(...)`
+- socket 生命周期切换 -> `Server::handle(...)`
+
+## 快照数据从哪里来
+
+`MasterReplicationClient::send_rdb_file(...)` 当前发送的是一段常量十六进制编码的空 RDB 文件。
+
+这并不是对当前内存状态的真实序列化，只是为了让协议流程能继续跑通。
+
+这也是当前实现和真实 Redis 差距最大的点之一。
+
+## 写命令如何广播
+
+一旦 replica socket 被注册，后续写命令就通过 `MasterReplicationClient::send_command(...)` 广播。
+
+它的逻辑很简单：
+
+1. 锁住 replica socket 列表
+2. 遍历每个连接
+3. 把编码后的命令写出去
+
+没有做每个 replica 的背压或独立状态管理。
+
+## 命令执行如何接上复制
+
+`cmd.rs` 中的写命令最终会调用 `resp_and_replicate(...)`。
+
+它根据节点角色做分支：
+
+- master -> 先广播给 replicas，再返回本地响应
+- slave 的普通客户端连接 -> 拒绝写入
+- slave 的复制连接 -> 接受来自 master 的回放命令
+
+这就是命令语义和复制规则真正交汇的地方。
+
+## Offset 跟踪
+
+`server.offset` 保存了一份粗粒度复制偏移量。
+
+命令执行成功后，会按协议编码长度去递增它；`REPLCONF GETACK` 则从这里读进度。
+
+这不是完整 Redis 的复制状态机，但足够表达“当前节点已经处理了多少复制流量”。
+
+## 当前实现限制
+
+- 快照来源是常量空 RDB
+- 不支持 partial resync
+- 没有 backlog 窗口
+- 没有 replica 存活状态管理
+- 除启动过程外，没有重连策略
+
+即便如此，它已经清楚展示了 leader-follower 复制的核心骨架：握手、全量同步、注册 socket、再广播写流量。

--- a/docs/zh/resp-protocol.md
+++ b/docs/zh/resp-protocol.md
@@ -1,0 +1,156 @@
+---
+title: RESP 协议
+layout: default
+nav_exclude: true
+permalink: /zh/docs/resp-protocol/
+---
+
+# RESP 协议
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [运行时与服务端]({{ '/zh/docs/server-runtime/' | relative_url }}) | [命令执行]({{ '/zh/docs/command-execution/' | relative_url }})
+
+这一章单独讨论项目里的 RESP 模型，以及它如何把 socket 输入和命令执行连接起来。
+
+## 文件边界
+
+- `src/protocol.rs`
+
+## 协议枚举
+
+项目内部使用 `Protocol` 作为统一协议表示，当前支持：
+
+- `SimpleString(String)`
+- `BulkString(String)`
+- `Null`
+- `Array(Vec<Protocol>)`
+
+这已经足够覆盖当前仓库的命令输入和响应输出。
+
+## 为什么这一层重要
+
+项目里几乎所有模块都建立在 `Protocol` 之上：
+
+- `Cmd::from(...)` 依赖它来判断收到的是哪条命令
+- `Protocol::encode(...)` 负责把执行结果重新变成 RESP 文本
+
+所以它既是入站适配层，也是出站适配层。
+
+## 解析入口
+
+`Protocol::from(protocol: &str)` 是总入口。
+
+它会检查首字符，并分发到三个后缀解析器：
+
+- `parse_simple_string_sfx(...)`
+- `parse_bulk_string_sfx(...)`
+- `parse_array_sfx(...)`
+
+返回值是一个二元组：
+
+- 解析后的 `Protocol`
+- 消耗掉的字节长度
+
+第二个值对于数组递归解析尤其重要。
+
+## Simple String
+
+`parse_simple_string_sfx(...)` 会找到第一个 `\\r\\n`，并把之前的内容作为 `SimpleString`。
+
+这一支最简单：
+
+- 没有长度前缀
+- 没有嵌套结构
+- 直接切片取值
+
+## Bulk String
+
+`parse_bulk_string_sfx(...)` 分两步：
+
+1. 先解析前面的长度声明
+2. 再取出对应长度的 payload，并校验实际长度是否匹配
+
+如果声明长度和实际内容长度不匹配，就直接报错，不做容错恢复。
+
+## 一个很重要的行为：会强制转小写
+
+bulk string 被接受后，当前实现会保存成：
+
+```rust
+Protocol::BulkString(s.to_lowercase())
+```
+
+这有利有弊。
+
+好处：
+
+- 命令关键字天然大小写不敏感
+
+代价：
+
+- bulk string 的原始大小写不会被保留
+- payload 不再是完全按字节保真的
+
+对于教学项目这是可接受的，但它确实和完整 Redis 行为不完全一致。
+
+## 数组解析
+
+`parse_array_sfx(...)` 会先读数组长度，再循环调用 `Protocol::from(...)` 去解析后续子元素。
+
+每个子元素都会返回“自己消耗了多少字节”，父解析器就用 `offset` 持续向前推进。
+
+数据流可以概括成：
+
+```text
+array header
+-> child 1 parse + len
+-> child 2 parse + len
+-> ...
+-> Protocol::Array(vec)
+```
+
+这也是为什么顶层解析函数必须返回“值 + 消耗长度”。
+
+## 构造辅助函数
+
+`protocol.rs` 还提供了一些命令层常用的 helper：
+
+- `from_vec(...)`
+- `ok()`
+- `err(...)`
+- `write_on_slave_err()`
+- `psync_on_slave_err()`
+- `none()`
+
+这样 `cmd.rs` 不需要在每个分支里手写小段 RESP 结构。
+
+## 编码路径
+
+`encode()` 负责把 `Protocol` 转回 RESP 文本：
+
+- `SimpleString` -> `+...\\r\\n`
+- `BulkString` -> `$len\\r\\npayload\\r\\n`
+- `Array` -> `*len\\r\\n` + 子元素编码结果
+- `Null` -> `$-1\\r\\n`
+
+这套编码路径被多个地方复用：
+
+- 普通客户端响应
+- 复制握手消息
+- 向 replica 广播写命令
+
+## 人类可读的 `decode()`
+
+`decode()` 会把 `Protocol` 展平成普通字符串。
+
+命令解析阶段大量依赖它，尤其是把数组转成 token 列表时。
+
+对数组来说，它会把子元素用空格拼接起来。这非常适合当前仓库的命令式解析需求，但并不是完全保结构的展示形式。
+
+## 当前实现限制
+
+- 解析输入是 `&str`，不是原始字节流
+- 没有更细的 RESP 类型区分
+- 结构上支持嵌套数组，但命令层只消费很窄的一部分
+- bulk string 强制小写会改变 payload 语义
+
+尽管如此，这一层依然是整个项目最关键的 wire-format 边界。

--- a/docs/zh/runtime-and-protocol.md
+++ b/docs/zh/runtime-and-protocol.md
@@ -1,0 +1,136 @@
+---
+title: 运行时与协议
+layout: default
+nav_exclude: true
+permalink: /zh/docs/runtime-and-protocol/
+---
+
+# 运行时与协议
+
+[返回首页]({{ '/' | relative_url }}) | [总览]({{ '/overview/' | relative_url }}) | [持久化与复制]({{ '/zh/docs/persistence-and-replication/' | relative_url }}) | [命令、流与事务]({{ '/zh/docs/commands-streams-and-transactions/' | relative_url }})
+
+这一章覆盖程序入口、TCP 服务循环，以及把原始 RESP 请求变成可执行命令的协议解析层。
+
+## 文件边界
+
+- `src/main.rs`
+- `src/server.rs`
+- `src/protocol.rs`
+- `src/options.rs`
+
+## 启动入口
+
+`src/main.rs` 是唯一的可执行入口。它解析四个 CLI 参数：
+
+- `--dir`
+- `--dbfilename`
+- `--port`
+- `--replicaof`
+
+这些参数会被组装成 `DBOption` 和 `ReplicationOption`，再传给 `Server::new(...)`。
+
+最关键的效果是：节点角色完全由命令行决定。只要传入 `--replicaof`，服务就会以 slave 模式启动；否则就是 master。
+
+## 监听模型
+
+服务通过 Tokio 的 `TcpListener` 绑定到 `127.0.0.1:<port>`。
+
+每收到一个新连接时，会执行这条链路：
+
+1. 克隆一份 `Server`
+2. 启动一个 Tokio 任务
+3. 把 socket 交给 `Server::handle(...)`
+
+因此，这个实现是“共享逻辑服务 + 每连接异步任务”，而不是单线程命令循环。
+
+## 共享状态
+
+`src/server.rs` 里的 `Server` 保存了几类共享状态：
+
+- `storage`：字符串键值存储
+- `streams`：Stream 数据
+- `option`：运行配置
+- `offset`：复制偏移量
+- `master_repl_clients`：master 下游的 replica 连接
+- `stream_reader_blocker`：阻塞式 `XREAD` 的唤醒通道
+
+其中普通 key-value 和 stream 数据走的是两把不同的 mutex，这让两类操作不需要共用同一把锁。
+
+## 连接处理循环
+
+`Server::handle(...)` 的主循环是：
+
+1. 读 socket 到固定缓冲区
+2. 按 UTF-8 解释
+3. 调用 `Cmd::from(...)`
+4. 执行 `cmd.run(...)`
+5. 如果不是复制连接，就把结果写回客户端
+
+这里使用的是固定 `512` 字节缓冲区，并且默认一次读取就能形成一条可解析命令。它比生产级 Redis 简化很多，但控制流非常直观。
+
+## RESP 解析器
+
+`src/protocol.rs` 定义了一个很小的 `Protocol` 枚举：
+
+- `SimpleString`
+- `BulkString`
+- `Null`
+- `Array`
+
+当前支持的 RESP 形态包括：
+
+- `+` 开头的简单字符串
+- `$` 开头的 bulk string
+- `*` 开头的数组
+
+`Protocol::from(...)` 会返回两个值：
+
+- 解析后的协议对象
+- 消耗的字节数
+
+这个“值 + 消耗长度”的返回方式会继续被数组解析复用。
+
+## 当前解析器的重要行为
+
+### Bulk string 会被转成小写
+
+`parse_bulk_string_sfx(...)` 在得到字符串后会调用 `to_lowercase()`。
+
+这意味着：
+
+- 命令关键字大小写不敏感
+- bulk string 负载内容也不会保留原始大小写
+
+这对教学实现很方便，但和完整 Redis 的“按字节保真”并不完全一致。
+
+### 编码辅助函数
+
+这个模块还提供了很多执行层依赖的辅助方法：
+
+- `Protocol::ok()`
+- `Protocol::err(...)`
+- `Protocol::none()`
+- `encode()`
+- `decode()`
+
+这些方法就是“命令执行结果”和“socket 写回格式”之间的公共边界。
+
+## 从节点启动的特殊流程
+
+如果节点以 slave 身份启动：
+
+1. 创建 `FollowerReplicationClient`
+2. 执行复制握手
+3. 接收并加载 master 发来的 RDB 快照
+4. 再启动一个 handler 任务来消费复制连接上的后续命令
+
+这一套高层流程仍然写在 `main.rs` 里，而不是被隐藏进 `Server::new(...)`，所以入口控制流很好追。
+
+## 当前实现限制
+
+- 固定大小 socket 读缓冲区
+- 默认读到的是完整 UTF-8 命令片段
+- 没有做跨多次 read 的增量协议拼接
+- 解析器更偏“能驱动当前命令集”，而不是完整 RESP 实现
+
+这些限制和仓库定位是一致的：重点是把 Redis 的请求生命周期讲清楚，而不是把协议边角做全。

--- a/docs/zh/server-runtime.md
+++ b/docs/zh/server-runtime.md
@@ -1,0 +1,164 @@
+---
+title: 运行时与服务端
+layout: default
+nav_exclude: true
+permalink: /zh/docs/server-runtime/
+---
+
+# 运行时与服务端
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [RESP 协议]({{ '/zh/docs/resp-protocol/' | relative_url }}) | [复制链路]({{ '/zh/docs/replication-flow/' | relative_url }})
+
+这一章从可执行入口开始，跟踪整个服务端运行时是怎么被搭起来的。
+
+## 文件边界
+
+- `src/main.rs`
+- `src/server.rs`
+- `src/options.rs`
+
+## 进程是如何启动的
+
+`src/main.rs` 是唯一的二进制入口，它解析四个 CLI 参数：
+
+- `--dir`
+- `--dbfilename`
+- `--port`
+- `--replicaof`
+
+然后把这些参数组装成 `DBOption` 和 `ReplicationOption`，再传入 `Server::new(...)`。
+
+这意味着节点角色在服务创建之前就已经确定：
+
+- 没有 `--replicaof` -> master
+- 有 `--replicaof` -> slave
+
+## 配置对象
+
+`src/options.rs` 只保留了一组很小的运行配置：
+
+`DBOption` 包含：
+
+- DB 目录
+- DB 文件名
+- 监听端口
+- 复制配置
+
+`ReplicationOption` 包含：
+
+- `role`
+- `master_replid`
+- `master_repl_offset`
+- `replica_of`
+
+这个项目没有动态角色发现逻辑，角色完全来自命令行配置。
+
+## 监听与任务模型
+
+`main.rs` 使用 Tokio 的 `TcpListener` 监听 `127.0.0.1:<port>`。
+
+每接到一个新连接，就执行：
+
+1. 克隆 `Server`
+2. 启动 Tokio 任务
+3. 调用 `Server::handle(...)`
+
+因此运行时模型可以概括成：
+
+- 一份共享逻辑服务端状态
+- 每个 socket 一个异步任务
+- 没有单独的中央调度线程
+
+## `Server` 里到底存了什么
+
+`src/server.rs` 里的 `Server` 是整个共享运行时外壳，关键字段有：
+
+- `storage: Arc<Mutex<Storage>>`
+- `streams: Arc<Mutex<HashMap<String, Stream>>>`
+- `option: DBOption`
+- `offset: Arc<AtomicU64>`
+- `master_repl_clients: Arc<Mutex<Option<MasterReplicationClient>>>`
+- `stream_reader_blocker: Arc<Mutex<Vec<Sender<()>>>>`
+- `master_addr: Option<String>`
+
+这里把普通字符串存储和 stream 存储拆成了两套容器，因此两类操作不会争用同一把锁。
+
+## `Server::new(...)` 做了什么
+
+`Server::new(...)` 的高层流程是：
+
+1. 如果自己是 slave，就从配置里推导 `master_addr`
+2. 分配共享状态容器
+3. 调用 `init().await`
+
+master 才会初始化下游 replica fan-out 客户端；slave 则没有这个对象。
+
+## Master 侧初始化
+
+`Server::init(...)` 当前只负责 master 节点的本地持久化恢复。
+
+控制流如下：
+
+1. 用 `dir + db_file_name` 拼出 DB 文件路径
+2. 如果文件不存在则创建
+3. 检查文件长度
+4. 如果非空，则进入 `rdb::parse_rdb_file(...)`
+
+slave 不走这里，因为它的初始状态来自主节点发来的快照。
+
+## Slave 侧启动链路
+
+slave 的特殊启动逻辑仍然显式写在 `main.rs`，没有被藏进构造函数里。
+
+顺序如下：
+
+1. 创建 `FollowerReplicationClient`
+2. `PING` master
+3. 上报监听端口
+4. 上报同步能力
+5. 发起 `PSYNC`
+6. 再为复制 socket 启动一个 `Server::handle(...)`
+
+这样从入口文件就能直接看到 slave 的完整启动过程。
+
+## 连接处理循环
+
+`Server::handle(...)` 是每个 socket 的主循环：
+
+1. 从 socket 读到固定 `512` 字节缓冲区
+2. 按 UTF-8 转成字符串
+3. 用 `Cmd::from(...)` 解析命令
+4. 通过 `cmd.run(...)` 执行
+5. 如果不是复制连接，就把结果写回客户端
+
+如果当前节点是 master，并且命令是 `PSYNC`，这个循环会切换模式：
+
+1. 发送 RDB 快照
+2. 把当前 socket 注册到 replica 列表
+3. 不再把它当普通请求-响应连接
+
+这就是普通客户端连接和复制连接在运行时分叉的地方。
+
+## 普通请求的数据流
+
+一个普通客户端请求的路径可以概括成：
+
+```text
+socket bytes
+-> Server::handle
+-> Cmd::from
+-> Cmd::run
+-> Protocol response
+-> socket write
+```
+
+`Server` 自己更像是一个编排层，而不是命令语义实现层。
+
+## 当前实现限制
+
+- 固定大小读缓冲区
+- 一次 read 默认只形成一条命令
+- 没有跨多次读取的增量协议拼接
+- 没有显式的 shutdown / supervisor 模型
+
+这些取舍让运行时入口保持得很短，也方便顺着源码追控制流。

--- a/docs/zh/storage-model.md
+++ b/docs/zh/storage-model.md
@@ -1,0 +1,129 @@
+---
+title: 存储模型
+layout: default
+nav_exclude: true
+permalink: /zh/docs/storage-model/
+---
+
+# 存储模型
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [RDB 解析器]({{ '/zh/docs/rdb-parser/' | relative_url }}) | [Streams 与事务]({{ '/zh/docs/streams-and-transactions/' | relative_url }})
+
+这一章聚焦项目里的内存存储层，以及 stream 为什么没有放进同一个容器。
+
+## 文件边界
+
+- `src/storage.rs`
+- `src/server.rs`
+
+## 字符串 key-value 存储
+
+`src/storage.rs` 定义了普通字符串键值存储，内部结构是：
+
+```text
+HashMap<String, (String, Option<u128>)>
+```
+
+每条记录包含：
+
+- 字符串值
+- 可选的绝对过期时间戳（毫秒）
+
+`ValueType` 这个 type alias 就是在表达这个结构。
+
+## 为什么过期时间存绝对时间戳
+
+这里不会保存：
+
+- 插入时间
+- 相对 TTL
+
+而是直接保存“绝对过期时间”。这样读路径很简单：
+
+- 取当前时间
+- 和记录中的过期时间比较
+- 过期就删掉
+- 没过期就返回值
+
+这同时适配：
+
+- `SET PX/EX`
+- RDB 恢复
+
+## `now_in_millis()`
+
+`now_in_millis()` 是整个项目的毫秒级时间源。
+
+它不仅用于字符串过期判断，也被 stream 的自动 ID 生成复用。
+
+所以“毫秒时间”其实是这个仓库多个子系统共享的基础原语。
+
+## 读路径
+
+`Storage::get(...)` 不只是查表，它还会顺带做惰性过期处理：
+
+1. 先查 `HashMap`
+2. 如果有过期时间，就和当前时间比较
+3. 如果过期，删除该键并返回 `None`
+4. 否则返回值的克隆
+
+这属于 lazy expiration，没有后台清理线程。
+
+## 写路径
+
+写接口保持得很小：
+
+- `set(...)`：写普通值
+- `setx(...)`：写带过期时间的值
+- `del(...)`：删键
+- `keys(...)`：列出当前 key
+
+其中 `setx(...)` 会把“相对 TTL”加上 `now_in_millis()`，转换成绝对时间戳后再保存。
+
+## 哪些数据不在这里
+
+Stream 不在 `Storage` 里，而是单独放在 `Server::streams`：
+
+```text
+HashMap<String, BTreeMap<String, Vec<(String, String)>>>
+```
+
+这样拆开的原因很直接：
+
+- 普通字符串键需要的是点查和可选过期
+- stream 需要按 entry id 有序范围查询
+
+内部使用 `BTreeMap`，可以天然支持有序遍历。
+
+## 命令层如何调用存储
+
+`cmd.rs` 里的大多数字符串命令流程都差不多：
+
+1. 锁住 `server.storage`
+2. 调用一个同步存储方法
+3. 解锁
+4. 构造 `Protocol` 响应
+
+因此 async 边界是在 `Server` 的 `Mutex` 外层，而不是在 `Storage` 内部。
+
+## 字符串命令的数据流
+
+像 `GET`、`SET`、`DEL`、`INCR` 的数据流可以概括成：
+
+```text
+cmd.rs helper
+-> lock server.storage
+-> 调用 Storage 方法
+-> 构造 Protocol 响应
+```
+
+这也是这个仓库可读性较高的原因之一：命令层没有把存储语义重新实现一遍。
+
+## 当前实现限制
+
+- 所有值都按字符串保存
+- 过期清理是惰性的
+- 没有容量统计和淘汰策略
+- `keys()` 不会主动过滤那些尚未被读取过的过期键
+
+这些限制是合理的，因为当前目标是把存储模型讲清楚，而不是实现完整 Redis 内存管理。

--- a/docs/zh/streams-and-transactions.md
+++ b/docs/zh/streams-and-transactions.md
@@ -1,0 +1,152 @@
+---
+title: Streams 与事务
+layout: default
+nav_exclude: true
+permalink: /zh/docs/streams-and-transactions/
+---
+
+# Streams 与事务
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [命令执行]({{ '/zh/docs/command-execution/' | relative_url }}) | [存储模型]({{ '/zh/docs/storage-model/' | relative_url }})
+
+这一章专门看两个比基础字符串命令更高一层的能力：Streams 和事务。
+
+## 文件边界
+
+- `src/cmd.rs`
+- `src/server.rs`
+
+## Stream 的存储结构
+
+Stream 不放在 `Storage` 里，而是放在 `Server::streams` 中。
+
+核心类型是：
+
+```text
+BTreeMap<String, Vec<(String, String)>>
+```
+
+整个容器则是：
+
+```text
+HashMap<String, Stream>
+```
+
+也就是：
+
+- 顶层 key -> stream 名
+- 有序 map key -> entry id
+- value -> field/value 对列表
+
+这里选择 `BTreeMap` 的核心原因，就是为了天然支持按 entry id 做有序范围查询。
+
+## Stream ID 解析
+
+`split_offset(...)` 是 stream offset / id 的底层 helper。
+
+它会拆出三部分：
+
+- 毫秒时间戳部分
+- sequence 部分
+- 是否使用了 wildcard sequence
+
+这个 helper 同时被读写路径复用，因此 stream 排序规则集中在一个地方。
+
+## `XADD`
+
+`xadd_cmd(...)` 负责 stream 写入，它的流程是：
+
+1. 把 `*` 归一化成 `now_in_millis()-*`
+2. 拆分 incoming id
+3. 拒绝非法 `0-0`
+4. 如果 stream 已存在，就和当前尾部 entry 比较
+5. 如果用了 wildcard，就推导最终 sequence
+6. 把 field/value 写进 stream entry
+7. 唤醒阻塞读者
+8. 如有需要，把原始命令复制到 replicas
+
+这是 stream 逻辑里最复杂的一条路径，因为它同时负责 ID 验证和 append 语义。
+
+## `XRANGE`
+
+`xrange_cmd(...)` 先把两个 Redis 特殊边界值转掉：
+
+- `-` -> 从最小开始
+- `+` -> 到最大结束
+
+然后使用 `BTreeMap::range(...)` 做范围查询，并把结果重新编码成 `Protocol::Array`。
+
+因此它的核心数据流是：
+
+```text
+stream key
+-> BTreeMap range
+-> 顺序遍历 entry
+-> 组装 Protocol::Array
+```
+
+## `XREAD`
+
+`xread_cmd(...)` 当前支持：
+
+- 多个 stream
+- 每个 stream 一个起始 offset
+- 可选阻塞模式
+
+阻塞逻辑有两种：
+
+- `BLOCK <millis>` 且大于 0 -> 直接 sleep
+- `BLOCK 0` -> 注册唤醒 sender，然后等通知
+
+第二种模式会借助 `server.stream_reader_blocker` 作为一个轻量等待队列。
+
+## 读者唤醒模型
+
+`XADD` 成功后，会拿到 `stream_reader_blocker`，向每个等待者发送一个空信号，然后清空列表。
+
+这个模型非常简单：
+
+- 不是按 stream 分组等待
+- 没有公平性调度
+- 只有一份全局等待者列表
+
+但它足够演示阻塞读取的基本思路。
+
+## 事务队列模型
+
+事务状态不是放在全局 `Server` 里，而是连接本地的：
+
+```text
+Option<Vec<(Cmd, Protocol)>>
+```
+
+这意味着事务只属于当前 client session，不会变成共享全局状态。
+
+## `MULTI`、`EXEC`、`DISCARD`
+
+事务控制流如下：
+
+- `MULTI` -> 创建空队列
+- 队列存在时，普通命令入队并返回 `QUEUED`
+- `EXEC` -> 通过 `cmd.run(...)` 依次重放队列
+- `DISCARD` -> 丢弃整个队列
+
+`exec_cmd(...)` 很紧凑，因为它没有造第二套“事务专用执行器”，而是直接复用现有命令执行路径。
+
+## 为什么事务队列里同时保存 `Cmd` 和 `Protocol`
+
+两者各自有作用：
+
+- `Cmd`：供 replay 时直接分发
+- `Protocol`：供复制和 offset 统计继续使用
+
+这样就不需要在事务执行阶段重新解析一次命令。
+
+## 当前实现限制
+
+- stream waiters 不是按 stream key 区分
+- `BLOCK <millis>` 用的是 sleep，而不是事件+超时组合
+- 事务队列是连接本地、非持久化的
+- stream 和事务边缘语义远少于真实 Redis
+
+尽管如此，这部分代码已经足够清楚地展示 higher-level Redis 功能是如何挂到统一命令执行链上的。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,310 @@
+---
+title: redis-rs
+permalink: /
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>redis-rs | Build Your Own Redis in Rust</title>
+    <meta
+      name="description"
+      content="A Redis clone in Rust with RESP parsing, RDB loading, replication, streams, and transactions."
+      data-i18n-content="meta.description"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=Manrope:wght@400;500;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{{ '/assets/css/homepage.css' | relative_url }}" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="hero" id="top">
+        <nav class="topbar" aria-label="Primary">
+          <a class="brand" href="#top">redis-rs</a>
+          <div class="topbar-actions">
+            <a
+              class="text-link"
+              href="{{ '/docs/overview/' | relative_url }}"
+              data-i18n="nav.overview"
+              data-i18n-href="nav.overviewHref"
+            >Detailed Docs</a>
+            <a class="text-link" href="https://github.com/fangpin/redis-rs" target="_blank" rel="noreferrer" data-i18n="nav.github">GitHub</a>
+            <div
+              class="language-toggle"
+              role="group"
+              aria-label="Language switcher"
+              data-i18n-aria-label="meta.languageSwitcher"
+            >
+              <button class="lang-btn is-active" type="button" data-lang="en" aria-pressed="true">EN</button>
+              <button class="lang-btn" type="button" data-lang="zh" aria-pressed="false">中文</button>
+            </div>
+          </div>
+        </nav>
+
+        <section class="hero-content">
+          <div class="hero-copy">
+            <p class="eyebrow" data-i18n="hero.eyebrow">Protocol. Persistence. Replication.</p>
+            <h1 data-i18n="hero.title">Build Your Own Redis in Rust</h1>
+            <p class="hero-description" data-i18n="hero.description">
+              A toy Redis server in Rust that parses RESP, restores from RDB, replicates leader-follower state, supports streams, and queues transactional commands.
+            </p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="https://github.com/fangpin/redis-rs" target="_blank" rel="noreferrer" data-i18n="hero.primaryCta">View on GitHub</a>
+              <a class="button button-secondary" href="#quickstart" data-i18n="hero.secondaryCta">Quick Start</a>
+              <a
+                class="button button-secondary"
+                href="{{ '/docs/overview/' | relative_url }}"
+                data-i18n="hero.docsCta"
+                data-i18n-href="hero.docsHref"
+              >Detailed Docs</a>
+            </div>
+          </div>
+
+          <div class="hero-panel" aria-hidden="true">
+            <div class="panel-surface">
+              <div class="panel-header">
+                <span>runtime.signal</span>
+                <span>redis-rs</span>
+              </div>
+              <div class="panel-grid">
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.protocol">Protocol</span>
+                  <strong>RESP</strong>
+                </div>
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.persistence">Persistence</span>
+                  <strong>RDB</strong>
+                </div>
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.replication">Replication</span>
+                  <strong>PSYNC</strong>
+                </div>
+                <div class="metric">
+                  <span class="metric-label" data-i18n="metrics.streams">Queues</span>
+                  <strong>XREAD</strong>
+                </div>
+              </div>
+              <pre class="signal-code"><code>cargo run -- --dir ./db --dbfilename dump.rdb
+redis-cli PING
+redis-cli INFO replication
+redis-cli XADD stream_key "*" foo bar</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <section class="docs-entry-section" id="docs-entry">
+          <div class="docs-entry-header">
+            <div>
+              <p class="eyebrow" data-i18n="docsEntry.eyebrow">Implementation docs</p>
+              <h2 data-i18n="docsEntry.title">Go straight to the detailed implementation docs</h2>
+            </div>
+            <a
+              class="button button-primary docs-entry-button"
+              href="{{ '/docs/overview/' | relative_url }}"
+              data-i18n="docsEntry.primaryCta"
+              data-i18n-href="docsEntry.primaryHref"
+            >Docs overview</a>
+          </div>
+          <div class="docs-link-grid">
+            <a
+              class="docs-link-card"
+              href="{{ '/docs/server-runtime/' | relative_url }}"
+              data-i18n-href="docsEntry.runtime.href"
+            >
+              <span class="docs-link-kicker" data-i18n="docsEntry.runtime.kicker">Runtime</span>
+              <strong data-i18n="docsEntry.runtime.title">Server runtime</strong>
+              <span class="docs-link-copy" data-i18n="docsEntry.runtime.body">Process entry, configuration, listener lifecycle, and shared server state.</span>
+            </a>
+            <a
+              class="docs-link-card"
+              href="{{ '/docs/resp-protocol/' | relative_url }}"
+              data-i18n-href="docsEntry.protocol.href"
+            >
+              <span class="docs-link-kicker" data-i18n="docsEntry.protocol.kicker">Protocol</span>
+              <strong data-i18n="docsEntry.protocol.title">RESP and storage</strong>
+              <span class="docs-link-copy" data-i18n="docsEntry.protocol.body">Wire format, parser, string storage, expiry, and stream containers.</span>
+            </a>
+            <a
+              class="docs-link-card"
+              href="{{ '/docs/replication-flow/' | relative_url }}"
+              data-i18n-href="docsEntry.replication.href"
+            >
+              <span class="docs-link-kicker" data-i18n="docsEntry.replication.kicker">Sync</span>
+              <strong data-i18n="docsEntry.replication.title">RDB and replication</strong>
+              <span class="docs-link-copy" data-i18n="docsEntry.replication.body">Snapshot parsing, handshake flow, full sync, and replica fan-out.</span>
+            </a>
+            <a
+              class="docs-link-card"
+              href="{{ '/docs/command-execution/' | relative_url }}"
+              data-i18n-href="docsEntry.commands.href"
+            >
+              <span class="docs-link-kicker" data-i18n="docsEntry.commands.kicker">Behavior</span>
+              <strong data-i18n="docsEntry.commands.title">Commands and transactions</strong>
+              <span class="docs-link-copy" data-i18n="docsEntry.commands.body">Dispatch, stream semantics, transaction replay, and the full chapter map.</span>
+            </a>
+          </div>
+        </section>
+      </header>
+
+      <main>
+        <section class="section capability-section" id="capabilities">
+          <div class="section-heading">
+            <p class="eyebrow" data-i18n="capabilities.eyebrow">Core capabilities</p>
+            <h2 data-i18n="capabilities.title">Built around real Redis subsystems</h2>
+          </div>
+          <div class="capability-grid">
+            <article class="capability-card">
+              <p class="card-kicker">01</p>
+              <h3 data-i18n="capabilities.protocol.title">Protocol</h3>
+              <p data-i18n="capabilities.protocol.body">Parses Redis protocol messages and routes commands through the server runtime.</p>
+              <span class="chip">protocol.rs</span>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">02</p>
+              <h3 data-i18n="capabilities.persistence.title">Persistence</h3>
+              <p data-i18n="capabilities.persistence.body">Loads database state from RDB files and restores key metadata.</p>
+              <span class="chip">rdb.rs</span>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">03</p>
+              <h3 data-i18n="capabilities.replication.title">Replication</h3>
+              <p data-i18n="capabilities.replication.body">Bootstraps replica handshake, full sync, and replicated write flow.</p>
+              <span class="chip">replication_client.rs</span>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">04</p>
+              <h3 data-i18n="capabilities.streams.title">Streams and transactions</h3>
+              <p data-i18n="capabilities.streams.body">Supports stream operations and queued transactional execution patterns.</p>
+              <span class="chip">cmd.rs</span>
+            </article>
+          </div>
+        </section>
+
+        <section class="section quickstart-section" id="quickstart">
+          <div class="section-heading">
+            <p class="eyebrow" data-i18n="quickstart.eyebrow">Run it</p>
+            <h2 data-i18n="quickstart.title">Start fast, then probe with redis-cli</h2>
+          </div>
+          <div class="command-deck">
+            <div class="command-card">
+              <div class="command-label" data-i18n="quickstart.masterLabel">Master</div>
+              <pre><code>cargo run -- --dir /some/db/path --dbfilename dump.rdb</code></pre>
+            </div>
+            <div class="command-card">
+              <div class="command-label" data-i18n="quickstart.replicaLabel">Replica</div>
+              <pre><code>cargo run -- --dir /some/db/path --dbfilename dump.rdb --port 6380 --replicaof "localhost 6379"</code></pre>
+            </div>
+            <div class="command-card command-card-wide">
+              <div class="command-label" data-i18n="quickstart.probeLabel">Probe</div>
+              <pre><code>redis-cli PING
+redis-cli SET foo bar
+redis-cli INFO replication
+redis-cli XREAD block 0 streams some_key 1526985054069-0</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <section class="section architecture-section" id="architecture">
+          <div class="section-heading">
+            <p class="eyebrow" data-i18n="architecture.eyebrow">Implementation map</p>
+            <h2 data-i18n="architecture.title">How the runtime is assembled</h2>
+          </div>
+          <div class="architecture-strip">
+            <article class="architecture-node">
+              <span class="node-file">protocol.rs</span>
+              <h3 data-i18n="architecture.protocol.title">Protocol ingestion</h3>
+              <p data-i18n="architecture.protocol.body">RESP parsing and request framing for incoming client and replication traffic.</p>
+            </article>
+            <article class="architecture-node">
+              <span class="node-file">server.rs + cmd.rs</span>
+              <h3 data-i18n="architecture.command.title">Command routing</h3>
+              <p data-i18n="architecture.command.body">Connection handling, command dispatch, and transaction orchestration.</p>
+            </article>
+            <article class="architecture-node">
+              <span class="node-file">storage.rs + rdb.rs</span>
+              <h3 data-i18n="architecture.storage.title">State and restore</h3>
+              <p data-i18n="architecture.storage.body">In-memory storage backed by RDB parsing and initial database hydration.</p>
+            </article>
+            <article class="architecture-node">
+              <span class="node-file">replication_client.rs</span>
+              <h3 data-i18n="architecture.replication.title">Replication flow</h3>
+              <p data-i18n="architecture.replication.body">Replica-side handshake, sync start, and downstream command consumption.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section docs-section" id="docs">
+          <div class="section-heading">
+            <p class="eyebrow" data-i18n="docs.eyebrow">Implementation docs</p>
+            <h2 data-i18n="docs.title">Follow the code by subsystem</h2>
+          </div>
+          <div class="capability-grid">
+            <article class="capability-card">
+              <p class="card-kicker">A</p>
+              <h3 data-i18n="docs.runtime.title">Server runtime</h3>
+              <p data-i18n="docs.runtime.body">Process entry, configuration, listener lifecycle, and shared server state.</p>
+              <a
+                class="inline-link"
+                href="{{ '/docs/server-runtime/' | relative_url }}"
+                data-i18n="docs.openChapter"
+                data-i18n-href="docs.runtime.href"
+              >Open chapter</a>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">B</p>
+              <h3 data-i18n="docs.persistence.title">RESP and storage</h3>
+              <p data-i18n="docs.persistence.body">RESP parsing and encoding, string storage, expiry model, and stream containers.</p>
+              <a
+                class="inline-link"
+                href="{{ '/docs/resp-protocol/' | relative_url }}"
+                data-i18n="docs.openChapter"
+                data-i18n-href="docs.persistence.href"
+              >Open chapter</a>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">C</p>
+              <h3 data-i18n="docs.commands.title">Persistence and replication</h3>
+              <p data-i18n="docs.commands.body">RDB parser internals, handshake flow, full sync, and replica fan-out.</p>
+              <a
+                class="inline-link"
+                href="{{ '/docs/replication-flow/' | relative_url }}"
+                data-i18n="docs.openChapter"
+                data-i18n-href="docs.commands.href"
+              >Open chapter</a>
+            </article>
+            <article class="capability-card">
+              <p class="card-kicker">D</p>
+              <h3 data-i18n="docs.overview.title">Command surface</h3>
+              <p data-i18n="docs.overview.body">Command dispatch, stream semantics, transaction replay, and the full chapter map.</p>
+              <a
+                class="inline-link"
+                href="{{ '/docs/overview/' | relative_url }}"
+                data-i18n="docs.openOverview"
+                data-i18n-href="docs.overview.href"
+              >Open overview</a>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="section footer-cta">
+        <div>
+          <p class="eyebrow" data-i18n="footer.eyebrow">Source and docs</p>
+          <h2 data-i18n="footer.title">Inspect the code, then dive deeper</h2>
+        </div>
+        <div class="footer-actions">
+          <a class="button button-primary" href="https://github.com/fangpin/redis-rs" target="_blank" rel="noreferrer" data-i18n="footer.github">Open GitHub Repository</a>
+          <a class="button button-secondary" href="https://github.com/fangpin/redis-rs/blob/master/README.md" target="_blank" rel="noreferrer" data-i18n="footer.readmeEn">Read README</a>
+          <a class="button button-secondary" href="https://github.com/fangpin/redis-rs/blob/master/README_CN.md" target="_blank" rel="noreferrer" data-i18n="footer.readmeZh">Read Chinese README</a>
+        </div>
+      </footer>
+    </div>
+
+    <script src="{{ '/assets/js/homepage.js' | relative_url }}"></script>
+  </body>
+</html>

--- a/index.md
+++ b/index.md
@@ -1,10 +1,14 @@
 ---
 title: 概览
 layout: default
-nav_order: 1
+nav_exclude: true
+permalink: /overview/
 ---
 
 # 概览
+
+[返回首页]({{ '/' | relative_url }}) | [文档总览]({{ '/zh/docs/overview/' | relative_url }}) | [运行时与服务端]({{ '/zh/docs/server-runtime/' | relative_url }}) | [RESP 协议]({{ '/zh/docs/resp-protocol/' | relative_url }})
+
 旨在从 0 到 1 实现一个基础的 redis-server 版本。其包含：
 
 - 解析标准的 Redis 协议；
@@ -35,6 +39,17 @@ nav_order: 1
   - 相信 Rust 光明的前景
 
 # 主要章节
+以下章节按源码边界拆分，适合作为从首页继续深入的阅读路线：
+
+- [文档总览]({{ '/zh/docs/overview/' | relative_url }})
+- [运行时与服务端]({{ '/zh/docs/server-runtime/' | relative_url }})
+- [RESP 协议]({{ '/zh/docs/resp-protocol/' | relative_url }})
+- [存储模型]({{ '/zh/docs/storage-model/' | relative_url }})
+- [RDB 解析器]({{ '/zh/docs/rdb-parser/' | relative_url }})
+- [复制链路]({{ '/zh/docs/replication-flow/' | relative_url }})
+- [命令执行]({{ '/zh/docs/command-execution/' | relative_url }})
+- [Streams 与事务]({{ '/zh/docs/streams-and-transactions/' | relative_url }})
+
 持续更新中，皆是会对一下章节附上索引链接
 
 基础功能：


### PR DESCRIPTION
## Summary
- build a bilingual GitHub Pages homepage for redis-rs with a prominent GitHub link and a clearer top-level docs entry
- add a dark just-the-docs theme override so detailed docs match the homepage visual system
- expand the implementation docs into finer-grained English and Chinese chapters for runtime, protocol, storage, RDB, replication, command execution, and streams/transactions

## Test Plan
- cargo test
- bundle _2.5.9_ exec jekyll build --baseurl "/redis-rs"
- verified local preview routes for homepage, docs overview, server-runtime, and zh docs overview return 200
